### PR TITLE
Fix init timing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPO=ros UPSTREAM_WORKSPACE=file
     - ROS_DISTRO="melodic" ROS_REPO=ros UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file
+    - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file CLANG_FORMAT_VERSION=6.0
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.h
+++ b/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.h
@@ -124,7 +124,8 @@ public:
         {
           if (this->verbose_)
             ROS_DEBUG_STREAM_THROTTLE_NAMED(1, this->name_,
-                                            "Finished executing last segment, checking goal tolerances");
+                                            "Finished executing last segment, checking goal "
+                                            "tolerances");
 
           // Controller uptime
           const ros::Time uptime = this->time_data_.readFromRT()->uptime;

--- a/ur_controllers/src/speed_scaling_state_controller.cpp
+++ b/ur_controllers/src/speed_scaling_state_controller.cpp
@@ -61,7 +61,7 @@ bool SpeedScalingStateController::init(SpeedScalingInterface* hw, ros::NodeHandl
   return true;
 }
 
-void SpeedScalingStateController ::starting(const ros::Time& time)
+void SpeedScalingStateController::starting(const ros::Time& time)
 {
   // initialize time
   for (unsigned i = 0; i < last_publish_times_.size(); i++)
@@ -70,7 +70,7 @@ void SpeedScalingStateController ::starting(const ros::Time& time)
   }
 }
 
-void SpeedScalingStateController ::update(const ros::Time& time, const ros::Duration& /*period*/)
+void SpeedScalingStateController::update(const ros::Time& time, const ros::Duration& /*period*/)
 {
   // limit rate of publishing
   for (unsigned i = 0; i < realtime_pubs_.size(); i++)
@@ -93,7 +93,7 @@ void SpeedScalingStateController ::update(const ros::Time& time, const ros::Dura
   }
 }
 
-void SpeedScalingStateController ::stopping(const ros::Time& /*time*/)
+void SpeedScalingStateController::stopping(const ros::Time& /*time*/)
 {
 }
 }  // namespace ur_controllers

--- a/ur_robot_driver/include/ur_robot_driver/comm/producer.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/producer.h
@@ -61,7 +61,7 @@ public:
   /*!
    * \brief Triggers the stream to connect to the robot.
    */
-  void setupProducer()
+  void setupProducer() override
   {
     timeval tv;
     tv.tv_sec = 1;
@@ -75,14 +75,14 @@ public:
   /*!
    * \brief Tears down the producer. Currently no special handling needed.
    */
-  void teardownProducer()
+  void teardownProducer() override
   {
     stopProducer();
   }
   /*!
    * \brief Stops the producer. Currently no functionality needed.
    */
-  void stopProducer()
+  void stopProducer() override
   {
     running_ = false;
   }
@@ -99,7 +99,7 @@ public:
    *
    * \returns Success of reading and parsing the package
    */
-  bool tryGet(std::vector<std::unique_ptr<URPackage<HeaderT>>>& products)
+  bool tryGet(std::vector<std::unique_ptr<URPackage<HeaderT>>>& products) override
   {
     // TODO This function has become really ugly! That should be refactored!
 

--- a/ur_robot_driver/include/ur_robot_driver/rtde/rtde_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/rtde/rtde_client.h
@@ -127,7 +127,7 @@ public:
 
 private:
   comm::URStream<PackageHeader> stream_;
-  std::vector<std::string> recipe_;
+  std::vector<std::string> output_recipe_;
   std::vector<std::string> input_recipe_;
   RTDEParser parser_;
   comm::URProducer<PackageHeader> prod_;
@@ -142,6 +142,11 @@ private:
   constexpr static const double URE_MAX_FREQUENCY = 500.0;
 
   std::vector<std::string> readRecipe(const std::string& recipe_file);
+
+  uint16_t negotiateProtocolVersion();
+  void queryURControlVersion();
+  void setupOutputs(const uint16_t protocol_version);
+  void setupInputs();
 };
 
 }  // namespace rtde_interface

--- a/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
@@ -118,6 +118,14 @@ public:
   bool writeKeepalive();
 
   /*!
+   * \brief Starts the RTDE communication.
+   *
+   * After initialization, the cyclic RTDE communication is not started automatically, so that data
+   * consumers can be started also at a later point.
+   */
+  void startRTDECommunication();
+
+  /*!
    * \brief Sends a stop command to the socket interface which will signal the program running on
    * the robot to no longer listen for commands sent from the remote pc.
    *

--- a/ur_robot_driver/src/comm/tcp_socket.cpp
+++ b/ur_robot_driver/src/comm/tcp_socket.cpp
@@ -177,7 +177,10 @@ bool TCPSocket::write(const uint8_t* buf, const size_t buf_len, size_t& written)
   written = 0;
 
   if (state_ != SocketState::Connected)
+  {
+    LOG_ERROR("Attempt to write on a non-connected socket");
     return false;
+  }
 
   size_t remaining = buf_len;
 
@@ -187,7 +190,10 @@ bool TCPSocket::write(const uint8_t* buf, const size_t buf_len, size_t& written)
     ssize_t sent = ::send(socket_fd_, buf + written, remaining, 0);
 
     if (sent <= 0)
+    {
+      LOG_ERROR("Sending data through socket failed.");
       return false;
+    }
 
     written += sent;
     remaining -= sent;

--- a/ur_robot_driver/src/primary/robot_state/kinematics_info.cpp
+++ b/ur_robot_driver/src/primary/robot_state/kinematics_info.cpp
@@ -88,7 +88,7 @@ std::string KinematicsInfo::toString() const
   return os.str();
 }
 
-std::string KinematicsInfo ::toHash() const
+std::string KinematicsInfo::toHash() const
 {
   std::stringstream ss;
   for (size_t i = 0; i < 6; ++i)

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -306,6 +306,7 @@ bool HardwareInterface ::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_h
   // Calling this service will make the "External Control" program node on the UR-Program return.
   deactivate_srv_ = robot_hw_nh.advertiseService("hand_back_control", &HardwareInterface::stopControl, this);
 
+  ur_driver_->startRTDECommunication();
   ROS_INFO_STREAM_NAMED("hardware_interface", "Loaded ur_robot_driver hardware_interface");
 
   return true;

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -49,7 +49,7 @@ HardwareInterface::HardwareInterface()
 {
 }
 
-bool HardwareInterface ::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
+bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
 {
   joint_velocities_ = { { 0, 0, 0, 0, 0, 0 } };
   joint_efforts_ = { { 0, 0, 0, 0, 0, 0 } };
@@ -336,7 +336,7 @@ void HardwareInterface::readBitsetData(const std::unique_ptr<rtde_interface::Dat
   }
 }
 
-void HardwareInterface ::read(const ros::Time& time, const ros::Duration& period)
+void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
 {
   std::unique_ptr<rtde_interface::DataPackage> data_pkg = ur_driver_->getDataPackage();
   if (data_pkg)
@@ -412,7 +412,7 @@ void HardwareInterface ::read(const ros::Time& time, const ros::Duration& period
   }
 }
 
-void HardwareInterface ::write(const ros::Time& time, const ros::Duration& period)
+void HardwareInterface::write(const ros::Time& time, const ros::Duration& period)
 {
   if ((runtime_state_ == static_cast<uint32_t>(rtde_interface::RUNTIME_STATE::PLAYING) ||
        runtime_state_ == static_cast<uint32_t>(rtde_interface::RUNTIME_STATE::PAUSING)) &&
@@ -433,8 +433,8 @@ void HardwareInterface ::write(const ros::Time& time, const ros::Duration& perio
   }
 }
 
-bool HardwareInterface ::prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                                       const std::list<hardware_interface::ControllerInfo>& stop_list)
+bool HardwareInterface::prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                                      const std::list<hardware_interface::ControllerInfo>& stop_list)
 {
   bool ret_val = true;
   if (controllers_initialized_ && !isRobotProgramRunning() && !start_list.empty())
@@ -455,8 +455,8 @@ bool HardwareInterface ::prepareSwitch(const std::list<hardware_interface::Contr
   return ret_val;
 }
 
-void HardwareInterface ::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                                  const std::list<hardware_interface::ControllerInfo>& stop_list)
+void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                                 const std::list<hardware_interface::ControllerInfo>& stop_list)
 {
   position_controller_running_ = false;
   for (auto& controller_it : start_list)
@@ -475,7 +475,7 @@ void HardwareInterface ::doSwitch(const std::list<hardware_interface::Controller
   }
 }
 
-uint32_t HardwareInterface ::getControlFrequency() const
+uint32_t HardwareInterface::getControlFrequency() const
 {
   if (ur_driver_ != nullptr)
   {
@@ -484,7 +484,7 @@ uint32_t HardwareInterface ::getControlFrequency() const
   throw std::runtime_error("ur_driver is not yet initialized");
 }
 
-void HardwareInterface ::transformForceTorque()
+void HardwareInterface::transformForceTorque()
 {
   tcp_force_.setValue(fts_measurements_[0], fts_measurements_[1], fts_measurements_[2]);
   tcp_torque_.setValue(fts_measurements_[3], fts_measurements_[4], fts_measurements_[5]);
@@ -498,12 +498,12 @@ void HardwareInterface ::transformForceTorque()
                         tcp_torque_.x(), tcp_torque_.y(), tcp_torque_.z() };
 }
 
-bool HardwareInterface ::isRobotProgramRunning() const
+bool HardwareInterface::isRobotProgramRunning() const
 {
   return robot_program_running_;
 }
 
-void HardwareInterface ::handleRobotProgramState(bool program_running)
+void HardwareInterface::handleRobotProgramState(bool program_running)
 {
   if (robot_program_running_ == false && program_running)
   {
@@ -515,7 +515,7 @@ void HardwareInterface ::handleRobotProgramState(bool program_running)
   program_state_pub_.publish(msg);
 }
 
-bool HardwareInterface ::shouldResetControllers()
+bool HardwareInterface::shouldResetControllers()
 {
   if (controller_reset_necessary_)
   {
@@ -528,7 +528,7 @@ bool HardwareInterface ::shouldResetControllers()
   }
 }
 
-void HardwareInterface ::extractToolPose(const ros::Time& timestamp)
+void HardwareInterface::extractToolPose(const ros::Time& timestamp)
 {
   double tcp_angle = std::sqrt(std::pow(tcp_pose_[3], 2) + std::pow(tcp_pose_[4], 2) + std::pow(tcp_pose_[5], 2));
 
@@ -546,7 +546,7 @@ void HardwareInterface ::extractToolPose(const ros::Time& timestamp)
   tcp_transform_.transform.rotation = tf2::toMsg(rotation);
 }
 
-void HardwareInterface ::publishPose()
+void HardwareInterface::publishPose()
 {
   if (tcp_pose_pub_)
   {

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -238,7 +238,7 @@ bool HardwareInterface ::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_h
   // Create ros_control interfaces
   for (std::size_t i = 0; i < joint_positions_.size(); ++i)
   {
-    ROS_DEBUG_STREAM("Registing handles for joint " << joint_names_[i]);
+    ROS_DEBUG_STREAM("Registering handles for joint " << joint_names_[i]);
     // Create joint state interface for all joints
     js_interface_.registerHandle(hardware_interface::JointStateHandle(joint_names_[i], &joint_positions_[i],
                                                                       &joint_velocities_[i], &joint_efforts_[i]));

--- a/ur_robot_driver/src/ros/hardware_interface_node.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface_node.cpp
@@ -56,28 +56,6 @@ int main(int argc, char** argv)
   // register signal SIGINT and signal handler
   signal(SIGINT, signalHandler);
 
-  // Set up timers
-  ros::Time timestamp;
-  ros::Duration period;
-  auto stopwatch_last = std::chrono::steady_clock::now();
-  auto stopwatch_now = stopwatch_last;
-
-  g_hw_interface.reset(new ur_driver::HardwareInterface);
-
-  if (!g_hw_interface->init(nh, nh_priv))
-  {
-    ROS_ERROR_STREAM("Could not correctly initialize robot. Exiting");
-    exit(1);
-  }
-  ROS_DEBUG_STREAM("initialized hw interface");
-  controller_manager::ControllerManager cm(g_hw_interface.get(), nh);
-
-  // Get current time and elapsed time since last read
-  timestamp = ros::Time::now();
-  stopwatch_now = std::chrono::steady_clock::now();
-  period.fromSec(std::chrono::duration_cast<std::chrono::duration<double>>(stopwatch_now - stopwatch_last).count());
-  stopwatch_last = stopwatch_now;
-
   std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
   bool has_realtime;
   realtime_file >> has_realtime;
@@ -126,6 +104,28 @@ int main(int argc, char** argv)
       ROS_ERROR("Could not get maximum thread priority for main thread");
     }
   }
+
+  // Set up timers
+  ros::Time timestamp;
+  ros::Duration period;
+  auto stopwatch_last = std::chrono::steady_clock::now();
+  auto stopwatch_now = stopwatch_last;
+
+  g_hw_interface.reset(new ur_driver::HardwareInterface);
+
+  if (!g_hw_interface->init(nh, nh_priv))
+  {
+    ROS_ERROR_STREAM("Could not correctly initialize robot. Exiting");
+    exit(1);
+  }
+  ROS_DEBUG_STREAM("initialized hw interface");
+  controller_manager::ControllerManager cm(g_hw_interface.get(), nh);
+
+  // Get current time and elapsed time since last read
+  timestamp = ros::Time::now();
+  stopwatch_now = std::chrono::steady_clock::now();
+  period.fromSec(std::chrono::duration_cast<std::chrono::duration<double>>(stopwatch_now - stopwatch_last).count());
+  stopwatch_last = stopwatch_now;
 
   double expected_cycle_time = 1.0 / (static_cast<double>(g_hw_interface->getControlFrequency()));
 

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -236,7 +236,7 @@ void rtde_interface::DataPackage::initEmpty()
   }
 }
 
-bool rtde_interface::DataPackage ::parseWith(comm::BinParser& bp)
+bool rtde_interface::DataPackage::parseWith(comm::BinParser& bp)
 {
   bp.parse(recipe_id_);
   for (auto& item : recipe_)

--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -138,7 +138,7 @@ void RTDEClient::setupOutputs(const uint16_t protocol_version)
     size = ControlPackageSetupOutputsRequest::generateSerializedRequest(buffer, output_recipe_);
   }
 
-  // Send input recipe to robot
+  // Send output recipe to robot
   if (!stream_.write(buffer, size, written))
     throw UrException("Could not send RTDE output recipe to robot.");
   if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))

--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -35,9 +35,9 @@ namespace rtde_interface
 RTDEClient::RTDEClient(std::string robot_ip, comm::INotifier& notifier, const std::string& output_recipe_file,
                        const std::string& input_recipe_file)
   : stream_(robot_ip, UR_RTDE_PORT)
-  , recipe_(readRecipe(output_recipe_file))
+  , output_recipe_(readRecipe(output_recipe_file))
   , input_recipe_(readRecipe(input_recipe_file))
-  , parser_(recipe_)
+  , parser_(output_recipe_)
   , prod_(stream_, parser_)
   , pipeline_(prod_, PIPELINE_NAME, notifier)
   , writer_(&stream_, input_recipe_)
@@ -50,13 +50,35 @@ bool RTDEClient::init()
   // A running pipeline is needed inside setup
   pipeline_.init();
   pipeline_.run();
+
+  uint16_t protocol_version = negotiateProtocolVersion();
+  parser_.setProtocolVersion(protocol_version);
+
+  queryURControlVersion();
+  if (urcontrol_version_.major < 5)
+  {
+    max_frequency_ = CB3_MAX_FREQUENCY;
+  }
+
+  setupOutputs(protocol_version);
+  setupInputs();
+
+  // We finished communication for now
+  pipeline_.stop();
+
+  // We throw exceptions on the way, so if we made it that far, we can return true.
+  return true;
+}
+
+uint16_t RTDEClient::negotiateProtocolVersion()
+{
   uint8_t buffer[4096];
   size_t size;
   size_t written;
-  // negotiate version
   uint16_t protocol_version = 2;
   size = RequestProtocolVersionRequest::generateSerializedRequest(buffer, protocol_version);
-  stream_.write(buffer, size, written);
+  if (!stream_.write(buffer, size, written))
+    throw UrException("Sending protocol version query to robot failed.");
   std::unique_ptr<comm::URPackage<PackageHeader>> package;
   if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
     throw UrException("Could not get urcontrol version from robot. This should not happen!");
@@ -66,7 +88,8 @@ bool RTDEClient::init()
   {
     protocol_version = 1;
     size = RequestProtocolVersionRequest::generateSerializedRequest(buffer, protocol_version);
-    stream_.write(buffer, size, written);
+    if (!stream_.write(buffer, size, written))
+      throw UrException("Sending protocol version query to robot failed.");
     if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
       throw UrException("Could not get urcontrol version from robot. This should not happen!");
     tmp_version = dynamic_cast<rtde_interface::RequestProtocolVersion*>(package.get());
@@ -75,13 +98,20 @@ bool RTDEClient::init()
       throw UrException("Neither protocol version 1 nor 2 was accepted by the robot. This should not happen!");
     }
   }
+  return protocol_version;
+}
 
-  parser_.setProtocolVersion(protocol_version);
-
-  // determine maximum frequency from ur-control version
+void RTDEClient::queryURControlVersion()
+{
+  uint8_t buffer[4096];
+  size_t size;
+  size_t written;
+  std::unique_ptr<comm::URPackage<PackageHeader>> package;
   size = GetUrcontrolVersionRequest::generateSerializedRequest(buffer);
-  stream_.write(buffer, size, written);
-  pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000));
+  if (!stream_.write(buffer, size, written))
+    throw UrException("Sending urcontrol version query request to robot failed.");
+  if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
+    throw UrException("Could not get urcontrol version from robot. This should not happen!");
   rtde_interface::GetUrcontrolVersion* tmp_urcontrol_version =
       dynamic_cast<rtde_interface::GetUrcontrolVersion*>(package.get());
 
@@ -90,40 +120,52 @@ bool RTDEClient::init()
     throw UrException("Could not get urcontrol version from robot. This should not happen!");
   }
   urcontrol_version_ = tmp_urcontrol_version->version_information_;
-  if (urcontrol_version_.major < 5)
-  {
-    max_frequency_ = CB3_MAX_FREQUENCY;
-  }
+}
 
-  // sending output recipe
+void RTDEClient::setupOutputs(const uint16_t protocol_version)
+{
+  size_t size;
+  size_t written;
+  uint8_t buffer[4096];
+  std::unique_ptr<comm::URPackage<PackageHeader>> package;
   LOG_INFO("Setting up RTDE communication with frequency %f", max_frequency_);
   if (protocol_version == 2)
   {
-    size = ControlPackageSetupOutputsRequest::generateSerializedRequest(buffer, max_frequency_, recipe_);
+    size = ControlPackageSetupOutputsRequest::generateSerializedRequest(buffer, max_frequency_, output_recipe_);
   }
   else
   {
-    size = ControlPackageSetupOutputsRequest::generateSerializedRequest(buffer, recipe_);
+    size = ControlPackageSetupOutputsRequest::generateSerializedRequest(buffer, output_recipe_);
   }
-  stream_.write(buffer, size, written);
-  pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000));
 
-  // sending input recipe
+  // Send input recipe to robot
+  if (!stream_.write(buffer, size, written))
+    throw UrException("Could not send RTDE output recipe to robot.");
+  if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
+    throw UrException("Did not receive confirmation on RTDE output recipe.");
+}
+
+void RTDEClient::setupInputs()
+{
+  size_t size;
+  size_t written;
+  uint8_t buffer[4096];
+  std::unique_ptr<comm::URPackage<PackageHeader>> package;
   size = ControlPackageSetupInputsRequest::generateSerializedRequest(buffer, input_recipe_);
-  stream_.write(buffer, size, written);
-  bool success = pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000));
+  if (!stream_.write(buffer, size, written))
+    throw UrException("Could not send RTDE input recipe to robot.");
+  if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
+    throw UrException("Did not receive confirmation on RTDE input recipe.");
   rtde_interface::ControlPackageSetupInputs* tmp_input =
       dynamic_cast<rtde_interface::ControlPackageSetupInputs*>(package.get());
   if (tmp_input == nullptr)
   {
     throw UrException("Could not setup RTDE inputs.");
   }
-  writer_.init(tmp_input->input_recipe_id_);
-  pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000));
 
-  pipeline_.stop();
-  return success;
+  writer_.init(tmp_input->input_recipe_id_);
 }
+
 bool RTDEClient::start()
 {
   uint8_t buffer[4096];
@@ -132,7 +174,8 @@ bool RTDEClient::start()
   pipeline_.run();
   size = ControlPackageStartRequest::generateSerializedRequest(buffer);
   std::unique_ptr<comm::URPackage<PackageHeader>> package;
-  stream_.write(buffer, size, written);
+  if (!stream_.write(buffer, size, written))
+    throw UrException("Sending RTDE start command failed!");
   if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))
     throw UrException("Could not get response to RTDE communication start request from robot. This should not happen!");
   rtde_interface::ControlPackageStart* tmp = dynamic_cast<rtde_interface::ControlPackageStart*>(package.get());

--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -47,6 +47,8 @@ RTDEClient::RTDEClient(std::string robot_ip, comm::INotifier& notifier, const st
 
 bool RTDEClient::init()
 {
+  // A running pipeline is needed inside setup
+  pipeline_.init();
   pipeline_.run();
   uint8_t buffer[4096];
   size_t size;
@@ -119,6 +121,7 @@ bool RTDEClient::init()
   writer_.init(tmp_input->input_recipe_id_);
   pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000));
 
+  pipeline_.stop();
   return success;
 }
 bool RTDEClient::start()
@@ -126,6 +129,7 @@ bool RTDEClient::start()
   uint8_t buffer[4096];
   size_t size;
   size_t written;
+  pipeline_.run();
   size = ControlPackageStartRequest::generateSerializedRequest(buffer);
   std::unique_ptr<comm::URPackage<PackageHeader>> package;
   stream_.write(buffer, size, written);

--- a/ur_robot_driver/src/rtde/rtde_package.cpp
+++ b/ur_robot_driver/src/rtde/rtde_package.cpp
@@ -36,7 +36,7 @@ bool RTDEPackage::parseWith(comm::BinParser& bp)
   return true;
 }
 
-std::string rtde_interface::RTDEPackage ::toString() const
+std::string rtde_interface::RTDEPackage::toString() const
 {
   std::stringstream ss;
   ss << "Type: " << static_cast<int>(type_) << std::endl;

--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -137,7 +137,6 @@ ur_driver::UrDriver::UrDriver(const std::string& robot_ip, const std::string& sc
   reverse_port_ = reverse_port;
   watchdog_thread_ = std::thread(&UrDriver::startWatchdog, this);
 
-  rtde_client_->start();  // TODO: Add extra start method (also to HW-Interface)
   LOG_DEBUG("Initialization done");
 }
 
@@ -165,6 +164,11 @@ bool UrDriver::writeKeepalive()
     return reverse_interface_->write(fake, 1);
   }
   return false;
+}
+
+void UrDriver::startRTDECommunication()
+{
+  rtde_client_->start();
 }
 
 bool UrDriver::stopControl()

--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -233,6 +233,7 @@ void UrDriver::checkCalibration(const std::string& checksum)
   }
   primary_interface::PrimaryParser parser;
   comm::URProducer<ur_driver::primary_interface::PackageHeader> prod(*primary_stream_, parser);
+  prod.setupProducer();
 
   CalibrationChecker consumer(checksum);
 


### PR DESCRIPTION
This MR aims at fixing startup timing issues like
 * Too much time goes by between starting the pipeline and starting robot control
 * Too much time goes by between the RTDE handshake and starting the pipeline

Also, we added more error handling (of cases that usually should not occur) to the RTDE handshake process.

This should solve #6 