### PR TITLE
When no controller is active, set the current point as setpoint.

### DIFF
--- a/ur_robot_driver/resources/servoj.urscript
+++ b/ur_robot_driver/resources/servoj.urscript
@@ -83,6 +83,8 @@ while keepalive > 0:
     if params_mult[1] > 1:
       q = [params_mult[2] / MULT_jointstate, params_mult[3] / MULT_jointstate, params_mult[4] / MULT_jointstate, params_mult[5] / MULT_jointstate, params_mult[6] / MULT_jointstate, params_mult[7] / MULT_jointstate]
       set_servo_setpoint(q)
+    else:
+      set_servo_setpoint(get_actual_joint_positions())
     end
   else:
     keepalive = keepalive - 1


### PR DESCRIPTION
This solves #26 

When no controller is active, we still send keepalive commands, which made the robot extrapolate the latest motion. Instead, we now send the current position as setpoint.