### PR TITLE
Remove industrial_msgs dependency.

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(catkin REQUIRED
     controller_manager
     geometry_msgs
     hardware_interface
-    industrial_msgs
     roscpp
     sensor_msgs
     std_srvs
@@ -40,7 +39,6 @@ catkin_package(
     controller_manager
     geometry_msgs
     hardware_interface
-    industrial_msgs
     roscpp
     sensor_msgs
     tf

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -27,7 +27,6 @@
   <depend>controller_manager</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
-  <depend>industrial_msgs</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf</depend>


### PR DESCRIPTION
As per subject.

I believe this is a left-over from `ur_modern_driver` but is not actually used in the current implementation.
