### PR TITLE
Support for combined robot hardware

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -90,8 +90,6 @@ add_library(ur_robot_driver
     src/primary/robot_message.cpp
     src/primary/robot_message/version_message.cpp
     src/primary/robot_state/kinematics_info.cpp
-    src/ros/dashboard_client_ros.cpp
-    src/ros/hardware_interface.cpp
     src/rtde/control_package_pause.cpp
     src/rtde/control_package_setup_inputs.cpp
     src/rtde/control_package_setup_outputs.cpp
@@ -111,9 +109,16 @@ add_library(ur_robot_driver
 target_link_libraries(ur_robot_driver ${catkin_LIBRARIES})
 add_dependencies(ur_robot_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
+add_library(ur_robot_driver_plugin
+  src/ros/dashboard_client_ros.cpp
+  src/ros/hardware_interface.cpp
+)
+target_link_libraries(ur_robot_driver_plugin ur_robot_driver ${catkin_LIBRARIES})
+add_dependencies(ur_robot_driver_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
 add_executable(ur_robot_driver_node
-  #src/ros/dashboard_client_ros.cpp
-  #src/ros/hardware_interface.cpp
+  src/ros/dashboard_client_ros.cpp
+  src/ros/hardware_interface.cpp
   src/ros/hardware_interface_node.cpp
 )
 target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_robot_driver)

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -112,8 +112,8 @@ target_link_libraries(ur_robot_driver ${catkin_LIBRARIES})
 add_dependencies(ur_robot_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(ur_robot_driver_node
-  src/ros/dashboard_client_ros.cpp
-  src/ros/hardware_interface.cpp
+  #src/ros/dashboard_client_ros.cpp
+  #src/ros/hardware_interface.cpp
   src/ros/hardware_interface_node.cpp
 )
 target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_robot_driver)

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED
     controller_manager
     geometry_msgs
     hardware_interface
+    pluginlib
     roscpp
     sensor_msgs
     std_srvs
@@ -39,6 +40,7 @@ catkin_package(
     controller_manager
     geometry_msgs
     hardware_interface
+    pluginlib
     roscpp
     sensor_msgs
     tf
@@ -88,6 +90,7 @@ add_library(ur_robot_driver
     src/primary/robot_message.cpp
     src/primary/robot_message/version_message.cpp
     src/primary/robot_state/kinematics_info.cpp
+    src/ros/hardware_interface.cpp
     src/rtde/control_package_pause.cpp
     src/rtde/control_package_setup_inputs.cpp
     src/rtde/control_package_setup_outputs.cpp
@@ -145,4 +148,8 @@ install(DIRECTORY config launch
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
+)
+
+install(FILES hardware_interface_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(ur_robot_driver
     src/primary/robot_message.cpp
     src/primary/robot_message/version_message.cpp
     src/primary/robot_state/kinematics_info.cpp
+    src/ros/dashboard_client_ros.cpp
     src/ros/hardware_interface.cpp
     src/rtde/control_package_pause.cpp
     src/rtde/control_package_setup_inputs.cpp

--- a/ur_robot_driver/hardware_interface_plugin.xml
+++ b/ur_robot_driver/hardware_interface_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libur_robot_driver">
+<library path="lib/libur_robot_driver_plugin">
   <class name="ur_driver/HardwareInterface" type="ur_driver::HardwareInterface" base_class_type="hardware_interface::RobotHW">
     <description>
       Universal Robots ROS Driver as plugin

--- a/ur_robot_driver/hardware_interface_plugin.xml
+++ b/ur_robot_driver/hardware_interface_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libur_robot_driver">
+  <class name="ur_driver/HardwareInterface" type="ur_driver::HardwareInterface" base_class_type="hardware_interface::RobotHW">
+    <description>
+      Universal Robots ROS Driver as plugin
+    </description>
+  </class>
+</library>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -27,6 +27,7 @@
   <depend>controller_manager</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf</depend>
@@ -47,6 +48,7 @@
   <exec_depend>velocity_controllers</exec_depend>
 
   <export>
+    <hardware_interface plugin="${prefix}/hardware_interface_plugin.xml" />
     <rosdoc config="doc/rosdoc.yaml" />
   </export>
 

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -24,7 +24,7 @@
  *
  */
 //----------------------------------------------------------------------
-
+#include <pluginlib/class_list_macros.hpp>
 #include "ur_robot_driver/ros/hardware_interface.h"
 #include "ur_robot_driver/ur/tool_communication.h"
 #include <ur_robot_driver/exceptions.h>
@@ -744,3 +744,5 @@ void HardwareInterface::publishRobotAndSafetyMode()
   }
 }
 }  // namespace ur_driver
+
+PLUGINLIB_EXPORT_CLASS(ur_driver::HardwareInterface, hardware_interface::RobotHW)


### PR DESCRIPTION
We propose the minimum set of changes to use the driver together with [combined_robot_hw](https://github.com/ros-controls/ros_control/tree/melodic-devel/combined_robot_hw).

In our setup we use a haptic device with an UR robot using the `combined_robot_hw` and it works fine. This change doesn't break anything, and even if this is not the final solution, at least someone could use it as we do. 

For example, we see some limitations to how the `combined_robot_hw` together with the driver handles `read` operations. If I'm correct `read` is a blocking operation, and the `combined_robot_hw` executes this operation for all hardwares consecutively. Even if I haven't tested yet, if we combine multiple arms together with with some extra hardware it won't work properly.

There are many things to discuss about `combined_robot_hw`, and it would be good to start discussing about it, if there is a real interest of course.

