### PR TITLE
Use a spawner to load stopped controllers to avoid confusion about fi…

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch
+++ b/ur_robot_driver/launch/ur_control.launch
@@ -60,8 +60,8 @@
     output="screen" args="$(arg controllers)" />
 
   <!-- load other controller -->
-  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load $(arg stopped_controllers)" />
+  <node name="ros_control_stopped_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="--stopped $(arg stopped_controllers)" />
 
 
   <node name="controller_stopper" pkg="controller_stopper" type="node" respawn="false" output="screen">


### PR DESCRIPTION
…nished nodes

Before, we used the controller_manager/controller_manager node to load unstarted
controllers, which logged a "finished cleanly" after loading the controllers.
This led to confusion as actually you don't expect something to exit when
starting the driver.

This resolves #36 