### PR TITLE
Always end script commands with a newline

### DIFF
--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -266,6 +266,9 @@ bool UrDriver::sendScript(const std::string& program)
                              "should not happen.");
   }
 
+  // urscripts (snippets) must end with a newline, or otherwise the controller's runtime will
+  // not execute them. To avoid problems, we always just append a newline here, even if
+  // there may already be one.
   auto program_with_newline = program + '\n';
 
   size_t len = program_with_newline.size();

--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -266,13 +266,15 @@ bool UrDriver::sendScript(const std::string& program)
                              "should not happen.");
   }
 
-  size_t len = program.size();
-  const uint8_t* data = reinterpret_cast<const uint8_t*>(program.c_str());
+  auto program_with_newline = program + '\n';
+
+  size_t len = program_with_newline.size();
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
   size_t written;
 
   if (secondary_stream_->write(data, len, written))
   {
-    LOG_DEBUG("Sent program to robot");
+    LOG_DEBUG("Sent program to robot:\n%s", program_with_newline.c_str());
     return true;
   }
   LOG_ERROR("Could not send program to robot");


### PR DESCRIPTION
Otherwise script will not be interpreted by the robot which might be counter-intuitive.
Changing the behavior as such will also be the same as in the ur_modern_driver
so migrating will be easier.

I decided to change the function's interface to copy the string in order add a
trailing '\n' if necessary.