### PR TITLE
Close all closable sockets

### DIFF
--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -102,9 +102,6 @@ bool URServer::accept()
 
 void URServer::disconnectClient()
 {
-  if (client_.getState() != comm::SocketState::Connected)
-    return;
-
   client_.close();
 }
 

--- a/ur_robot_driver/src/comm/tcp_socket.cpp
+++ b/ur_robot_driver/src/comm/tcp_socket.cpp
@@ -118,11 +118,12 @@ bool TCPSocket::setSocketFD(int socket_fd)
 
 void TCPSocket::close()
 {
-  if (state_ != SocketState::Connected)
-    return;
-  state_ = SocketState::Closed;
-  ::close(socket_fd_);
-  socket_fd_ = -1;
+  if (socket_fd_ >= 0)
+  {
+    state_ = SocketState::Closed;
+    ::close(socket_fd_);
+    socket_fd_ = -1;
+  }
 }
 
 std::string TCPSocket::getIP() const

--- a/ur_robot_driver/src/ur/ur_driver.cpp
+++ b/ur_robot_driver/src/ur/ur_driver.cpp
@@ -204,6 +204,11 @@ void UrDriver::startWatchdog()
 
     LOG_INFO("Connection to robot dropped, waiting for new connection.");
     handle_program_state_(false);
+    // We explicitly call the destructor here, as unique_ptr.reset() creates a new object before
+    // replacing the pointer and destroying the old object. This will result in a resource conflict
+    // when trying to bind the socket.
+    // TODO: It would probably make sense to keep the same instance alive for the complete runtime
+    // instead of killing it all the time.
     reverse_interface_->~ReverseInterface();
     reverse_interface_.reset(new comm::ReverseInterface(reverse_port_));
     reverse_interface_active_ = true;


### PR DESCRIPTION
Sockets do not necessarily have to be in state connected when they should be
closed. Before, only connected sockets got closed leading to a "socket leak"
if a socket was disconnected before a close request was processed.

With this fix all sockets with a valid file descriptor get closed when close()
is being called.

This fixes #91 