### PR TITLE
F ignore empty list in do switch

### DIFF
--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -518,8 +518,11 @@ bool HardwareInterface::prepareSwitch(const std::list<hardware_interface::Contro
 void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
                                  const std::list<hardware_interface::ControllerInfo>& stop_list)
 {
-  position_controller_running_ = false;
-  velocity_controller_running_ = false;
+  if ((!stop_list.empty()) || (!start_list.empty()))
+  {
+    position_controller_running_ = false;
+    velocity_controller_running_ = false;
+  }
   for (auto& controller_it : start_list)
   {
     for (auto& resource_it : controller_it.claimed_resources)


### PR DESCRIPTION
Currently, if doSwitch is called with empty lists for start_list and stop_list, it will stop communication to an arm. This is a problem when used with combined_robot_hw, as combined_robot_hw will call the doSwitch method of all instances of hardware_interface when a controller is started, but only pass one instance a list containing a controller, stopping any other instances started by combined_robot_hw. This pr makes sure that either the start_list or the stop_list contains something before halting communications. 