### PR TITLE
F parameterise using local hardware interface param

### DIFF
--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -281,7 +281,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // Names of the joints. Usually, this is given in the controller config file.
   if (!hardware_interface_nh->getParam("hardware_interface/joints", joint_names_))
   {
-    ROS_ERROR_STREAM("Cannot find required parameter " 
+    ROS_ERROR_STREAM("Cannot find required parameter "
                      << hardware_interface_nh->resolveName("hardware_interface/joints") << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -281,7 +281,8 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // Names of the joints. Usually, this is given in the controller config file.
   if (!hardware_interface_nh->getParam("hardware_interface/joints", joint_names_))
   {
-    ROS_ERROR_STREAM("Cannot find required parameter " << hardware_interface_nh->resolveName("hardware_interface/joints")
+    ROS_ERROR_STREAM("Cannot find required parameter " << hardware_interface_nh->
+                                                          resolveName("hardware_interface/joints")
                                                        << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -282,8 +282,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   if (!hardware_interface_nh->getParam("hardware_interface/joints", joint_names_))
   {
     ROS_ERROR_STREAM("Cannot find required parameter " 
-                     << hardware_interface_nh->resolveName("hardware_interface/joints")
-                     << " on the parameter server.");
+                     << hardware_interface_nh->resolveName("hardware_interface/joints") << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");
   }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -267,7 +267,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // end
   command_sub_ = robot_hw_nh.subscribe("script_command", 1, &HardwareInterface::commandCallback, this);
 
-  ros::NodeHandle *hardware_interface_nh;
+  ros::NodeHandle* hardware_interface_nh;
 
   if (use_local_hardware_interface_param)
   {
@@ -281,9 +281,9 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // Names of the joints. Usually, this is given in the controller config file.
   if (!hardware_interface_nh->getParam("hardware_interface/joints", joint_names_))
   {
-    ROS_ERROR_STREAM("Cannot find required parameter " << hardware_interface_nh->
-                                                          resolveName("hardware_interface/joints")
-                                                       << " on the parameter server.");
+    ROS_ERROR_STREAM("Cannot find required parameter " 
+                     << hardware_interface_nh->resolveName("hardware_interface/joints")
+                     << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");
   }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -129,6 +129,10 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
     return false;
   }
 
+  // Allows the hardware_interface parameter to be in the local (rather than global) namespace
+  // of the driver. This allows multiple drivers to be started in the same namespace.
+  bool use_local_hardware_interface_param = robot_hw_nh.param("use_local_hardware_interface_param", false);
+
   // Whenever the runtime state of the "External Control" program node in the UR-program changes, a
   // message gets published here. So this is equivalent to the information whether the robot accepts
   // commands from ROS side.
@@ -263,10 +267,21 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // end
   command_sub_ = robot_hw_nh.subscribe("script_command", 1, &HardwareInterface::commandCallback, this);
 
-  // Names of the joints. Usually, this is given in the controller config file.
-  if (!root_nh.getParam("hardware_interface/joints", joint_names_))
+  ros::NodeHandle *hardware_interface_nh;
+
+  if (use_local_hardware_interface_param)
   {
-    ROS_ERROR_STREAM("Cannot find required parameter " << root_nh.resolveName("hardware_interface/joints")
+    hardware_interface_nh = &robot_hw_nh;
+  }
+  else
+  {
+    hardware_interface_nh = &root_nh;
+  }
+
+  // Names of the joints. Usually, this is given in the controller config file.
+  if (!hardware_interface_nh->getParam("hardware_interface/joints", joint_names_))
+  {
+    ROS_ERROR_STREAM("Cannot find required parameter " << hardware_interface_nh->resolveName("hardware_interface/joints")
                                                        << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");


### PR DESCRIPTION
In it's current form, this driver won't allow multiple arms to exist in the same namespace. This pr fixes that by adding a parameter that allows the hardware_interface/joints parameter to be loaded from the drivers local namespace instead of the global one. 