### PR TITLE
Use SPDX license identifiers

### DIFF
--- a/controller_stopper/package.xml
+++ b/controller_stopper/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>Apache 2.0</license>
+  <license>Apache-2.0</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ur_calibration/package.xml
+++ b/ur_calibration/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>Apache 2.0</license>
+  <license>Apache-2.0</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>Apache 2.0</license>
+  <license>Apache-2.0</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ur_dashboard_msgs/package.xml
+++ b/ur_dashboard_msgs/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>Apache 2.0</license>
+  <license>Apache-2.0</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -10,8 +10,8 @@
   <author>Lea Steffen</author>
   <author>Tristan Schnell</author>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
-  <license>Apache 2.0</license>
-  <license>BSD 2-clause</license>
+  <license>Apache-2.0</license>
+  <license>BSD-2-Clause</license>
   <license>Zlib</license>
 
   <url type="website">http://wiki.ros.org/ur_robot_driver</url>


### PR DESCRIPTION
As per subject.

This reduces ambiguity and facilitates automated parsing and identification of licenses.

Refer to [spdx.org](https://spdx.org) for more information.
