### PR TITLE
Added case label statement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,6 +52,7 @@ BreakBeforeBraces: Custom
 
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       env:
         ROS_DISTRO: melodic
         CLANG_FORMAT_CHECK: file
-        CLANG_FORMAT_VERSION: "6.0"
+        CLANG_FORMAT_VERSION: "9"
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This statement was missing in the clang-format specification. At least with newer clang-format versions this is not being checked properly, otherwise.