### PR TITLE
Improve primary interface

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -83,11 +83,7 @@ include_directories(
 add_library(ur_robot_driver
     src/comm/tcp_socket.cpp
     src/comm/server.cpp
-    #src/ros/service_stopper.cpp
-    #src/ur/commander.cpp
-    #src/ur/master_board.cpp
-    #src/ur/messages.cpp
-    #src/ur/robot_mode.cpp
+    src/primary/primary_client.cpp
     src/primary/primary_package.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library(ur_robot_driver
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp
     src/primary/robot_message/version_message.cpp
+    src/primary/robot_message/text_message.cpp
+    src/primary/robot_message/key_message.cpp
     src/primary/robot_state/kinematics_info.cpp
     src/rtde/control_package_pause.cpp
     src/rtde/control_package_setup_inputs.cpp

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(ur_robot_driver
     src/primary/primary_package.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp
+    src/primary/robot_message/error_code_message.cpp
+    src/primary/robot_message/runtime_exception_message.cpp
     src/primary/robot_message/version_message.cpp
     src/primary/robot_message/text_message.cpp
     src/primary/robot_message/key_message.cpp

--- a/ur_robot_driver/include/ur_robot_driver/comm/producer.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/producer.h
@@ -57,6 +57,8 @@ public:
   {
   }
 
+  virtual ~URProducer() = default;
+
   /*!
    * \brief Triggers the stream to connect to the robot.
    */

--- a/ur_robot_driver/include/ur_robot_driver/primary/abstract_primary_consumer.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/abstract_primary_consumer.h
@@ -30,6 +30,10 @@
 
 #include "ur_robot_driver/log.h"
 #include "ur_robot_driver/comm/pipeline.h"
+#include "ur_robot_driver/primary/robot_message/error_code_message.h"
+#include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_robot_driver/primary/robot_message/runtime_exception_message.h"
+#include "ur_robot_driver/primary/robot_message/text_message.h"
 #include "ur_robot_driver/primary/robot_message/version_message.h"
 #include "ur_robot_driver/primary/robot_state/kinematics_info.h"
 
@@ -70,6 +74,10 @@ public:
   // To be implemented in specific consumers
   virtual bool consume(RobotMessage& pkg) = 0;
   virtual bool consume(RobotState& pkg) = 0;
+  virtual bool consume(ErrorCodeMessage& pkg) = 0;
+  virtual bool consume(KeyMessage& pkg) = 0;
+  virtual bool consume(RuntimeExceptionMessage& pkg) = 0;
+  virtual bool consume(TextMessage& pkg) = 0;
   virtual bool consume(VersionMessage& pkg) = 0;
   virtual bool consume(KinematicsInfo& pkg) = 0;
 

--- a/ur_robot_driver/include/ur_robot_driver/primary/key_message_handler.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/key_message_handler.h
@@ -49,7 +49,7 @@ public:
    */
   virtual void handle(KeyMessage& pkg) override
   {
-    LOG_INFO("%s", pkg.toString().c_str());
+    LOG_INFO("---KeyMessage---\n%s", pkg.toString().c_str());
   }
 
 private:

--- a/ur_robot_driver/include/ur_robot_driver/primary/key_message_handler.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/key_message_handler.h
@@ -1,0 +1,60 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+//
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+#define UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+
+#include <ur_robot_driver/log.h>
+#include <ur_robot_driver/primary/primary_package_handler.h>
+#include <ur_robot_driver/primary/robot_message/key_message.h>
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+class KeyMessageHandler : public IPrimaryPackageHandler<KeyMessage>
+{
+public:
+  KeyMessageHandler() = default;
+  virtual ~KeyMessageHandler() = default;
+
+  /*!
+   * \brief Actual worker function
+   *
+   * \param pkg package that should be handled
+   */
+  virtual void handle(KeyMessage& pkg) override
+  {
+    LOG_INFO("%s", pkg.toString().c_str());
+  }
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+#endif  // ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_client.h
@@ -31,6 +31,8 @@
 #include <ur_robot_driver/comm/producer.h>
 #include <ur_robot_driver/comm/stream.h>
 #include <ur_robot_driver/comm/pipeline.h>
+#include <ur_robot_driver/ur/calibration_checker.h>
+#include <ur_robot_driver/primary/primary_consumer.h>
 
 namespace ur_driver
 {
@@ -40,13 +42,31 @@ class PrimaryClient
 {
 public:
   PrimaryClient() = delete;
-  PrimaryClient(const std::string& robot_ip);
+  PrimaryClient(const std::string& robot_ip, const std::string& calibration_checksum);
   virtual ~PrimaryClient() = default;
+
+  /*!
+   * \brief Sends a custom script program to the robot.
+   *
+   * The given code must be valid according the UR Scripting Manual.
+   *
+   * \param script_code URScript code that shall be executed by the robot.
+   *
+   * \returns true on successful upload, false otherwise.
+   */
+  bool sendScript(const std::string& script_code);
+
+  /*!
+   * \brief Checks if the kinematics information in the used model fits the actual robot.
+   *
+   * \param checksum Hash of the used kinematics information
+   */
+  void checkCalibration(const std::string& checksum);
 
 private:
   std::string robot_ip_;
   PrimaryParser parser_;
-  std::unique_ptr<comm::IConsumer<PrimaryPackage>> consumer_;
+  std::unique_ptr<PrimaryConsumer> consumer_;
   comm::INotifier notifier_;
   std::unique_ptr<comm::URProducer<PrimaryPackage>> producer_;
   std::unique_ptr<comm::URStream<PrimaryPackage>> stream_;

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_client.h
@@ -1,0 +1,59 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+#ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+
+#include <ur_robot_driver/primary/primary_parser.h>
+#include <ur_robot_driver/comm/producer.h>
+#include <ur_robot_driver/comm/stream.h>
+#include <ur_robot_driver/comm/pipeline.h>
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+class PrimaryClient
+{
+public:
+  PrimaryClient() = delete;
+  PrimaryClient(const std::string& robot_ip);
+  virtual ~PrimaryClient() = default;
+
+private:
+  std::string robot_ip_;
+  PrimaryParser parser_;
+  std::unique_ptr<comm::IConsumer<PrimaryPackage>> consumer_;
+  comm::INotifier notifier_;
+  std::unique_ptr<comm::URProducer<PrimaryPackage>> producer_;
+  std::unique_ptr<comm::URStream<PrimaryPackage>> stream_;
+  std::unique_ptr<comm::Pipeline<PrimaryPackage>> pipeline_;
+};
+
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_consumer.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_consumer.h
@@ -1,0 +1,137 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+//
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/comm/pipeline.h"
+#include "ur_robot_driver/primary/primary_package_handler.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
+#include "ur_robot_driver/primary/key_message_handler.h"
+#include "ur_robot_driver/primary/robot_message/error_code_message.h"
+#include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_robot_driver/primary/robot_message/runtime_exception_message.h"
+#include "ur_robot_driver/primary/robot_message/text_message.h"
+#include "ur_robot_driver/primary/robot_message/version_message.h"
+#include "ur_robot_driver/primary/robot_state/kinematics_info.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief Primary consumer implementation
+ *
+ * This class implements am AbstractPrimaryConsumer such that it can consume all incoming primary
+ * messages. However, actual work will be done by workers for each specific type.
+ */
+class PrimaryConsumer : public AbstractPrimaryConsumer
+{
+public:
+  PrimaryConsumer()
+  {
+    LOG_INFO("Constructing primary consumer");
+    key_message_worker_.reset(new KeyMessageHandler());
+    LOG_INFO("Constructed primary consumer");
+  }
+  virtual ~PrimaryConsumer() = default;
+
+  virtual bool consume(RobotMessage& msg) override
+  {
+    LOG_INFO("---RobotMessage:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RobotState& msg) override
+  {
+    // LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(ErrorCodeMessage& msg) override
+  {
+    LOG_INFO("---ErrorCodeMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RuntimeExceptionMessage& msg) override
+  {
+    LOG_INFO("---RuntimeExceptionMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(TextMessage& msg) override
+  {
+    LOG_INFO("---TextMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(VersionMessage& msg) override
+  {
+    LOG_INFO("---VersionMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+
+  /*!
+   * \brief Handle a KinematicsInfo
+   *
+   * \returns True if there's a handler for this message type registered. False otherwise.
+   */
+  virtual bool consume(KinematicsInfo& pkg) override
+  {
+    if (kinematics_info_message_worker_ != nullptr)
+    {
+      kinematics_info_message_worker_->handle(pkg);
+      return true;
+    }
+    return false;
+  }
+
+  /*!
+   * \brief Handle a KeyMessage
+   *
+   * \returns True if there's a handler for this message type registered. False otherwise.
+   */
+  virtual bool consume(KeyMessage& pkg) override
+  {
+    if (key_message_worker_ != nullptr)
+    {
+      key_message_worker_->handle(pkg);
+      return true;
+    }
+    return false;
+  }
+
+  void setKinematicsInfoHandler(const std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>>& handler)
+  {
+    kinematics_info_message_worker_ = handler;
+  }
+
+private:
+  std::shared_ptr<IPrimaryPackageHandler<KeyMessage>> key_message_worker_;
+  std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>> kinematics_info_message_worker_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_package_handler.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_package_handler.h
@@ -1,0 +1,58 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+//
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief Interface for a class handling a primary interface package. Classes that implement this
+ * interface with a specific package type will be able to handle packages of this type.
+ */
+template <typename PackageT>
+class IPrimaryPackageHandler
+{
+public:
+  IPrimaryPackageHandler() = default;
+  virtual ~IPrimaryPackageHandler() = default;
+
+  /*!
+   * \brief Actual worker function
+   *
+   * \param pkg package that should be handled
+   */
+  virtual void handle(PackageT& pkg) = 0;
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
@@ -115,7 +115,7 @@ public:
       case RobotPackageType::ROBOT_MESSAGE:
       {
         uint64_t timestamp;
-        uint8_t source;
+        int8_t source;
         RobotMessagePackageType message_type;
 
         bp.parse(timestamp);

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
@@ -175,7 +175,7 @@ private:
       case RobotMessagePackageType::ROBOT_MESSAGE_VERSION:
         return new VersionMessage(timestamp, source);
       default:
-        return new RobotMessage(timestamp, source);
+        return new RobotMessage(timestamp, source, type);
     }
   }
 };

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
@@ -27,6 +27,8 @@
 #include "ur_robot_driver/primary/robot_state.h"
 #include "ur_robot_driver/primary/robot_message.h"
 #include "ur_robot_driver/primary/robot_state/kinematics_info.h"
+#include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_robot_driver/primary/robot_message/text_message.h"
 #include "ur_robot_driver/primary/robot_message/version_message.h"
 
 namespace ur_driver
@@ -174,6 +176,10 @@ private:
         return new MBD;*/
       case RobotMessagePackageType::ROBOT_MESSAGE_VERSION:
         return new VersionMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_TEXT:
+        return new TextMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_KEY:
+        return new KeyMessage(timestamp, source);
       default:
         return new RobotMessage(timestamp, source, type);
     }

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_parser.h
@@ -28,6 +28,8 @@
 #include "ur_robot_driver/primary/robot_message.h"
 #include "ur_robot_driver/primary/robot_state/kinematics_info.h"
 #include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_robot_driver/primary/robot_message/error_code_message.h"
+#include "ur_robot_driver/primary/robot_message/runtime_exception_message.h"
 #include "ur_robot_driver/primary/robot_message/text_message.h"
 #include "ur_robot_driver/primary/robot_message/version_message.h"
 
@@ -180,6 +182,10 @@ private:
         return new TextMessage(timestamp, source);
       case RobotMessagePackageType::ROBOT_MESSAGE_KEY:
         return new KeyMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_ERROR_CODE:
+        return new ErrorCodeMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_RUNTIME_EXCEPTION:
+        return new RuntimeExceptionMessage(timestamp, source);
       default:
         return new RobotMessage(timestamp, source, type);
     }

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_shell_consumer.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_shell_consumer.h
@@ -49,7 +49,7 @@ public:
   }
   virtual bool consume(RobotState& msg) override
   {
-    LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    //LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
     return true;
   }
   virtual bool consume(ErrorCodeMessage& msg) override

--- a/ur_robot_driver/include/ur_robot_driver/primary/primary_shell_consumer.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/primary_shell_consumer.h
@@ -1,0 +1,92 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+class PrimaryShellConsumer : public AbstractPrimaryConsumer
+{
+public:
+  PrimaryShellConsumer() = default;
+  virtual ~PrimaryShellConsumer() = default;
+
+  virtual bool consume(RobotMessage& msg) override
+  {
+    LOG_INFO("---RobotMessage:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RobotState& msg) override
+  {
+    LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(ErrorCodeMessage& msg) override
+  {
+    LOG_INFO("---ErrorCodeMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(KeyMessage& msg) override
+  {
+    LOG_INFO("---KeyMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RuntimeExceptionMessage& msg) override
+  {
+    LOG_INFO("---RuntimeExceptionMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(TextMessage& msg) override
+  {
+    LOG_INFO("---TextMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(VersionMessage& msg) override
+  {
+    LOG_INFO("---VersionMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(KinematicsInfo& msg) override
+  {
+    LOG_INFO("%s", msg.toString().c_str());
+    return true;
+  }
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message.h
@@ -65,6 +65,18 @@ public:
   RobotMessage(const uint64_t timestamp, const int8_t source) : timestamp_(timestamp), source_(source)
   {
   }
+
+  /*!
+   * \brief Creates a new RobotMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   * \param message_type The package's message type
+   */
+  RobotMessage(const uint64_t timestamp, const int8_t source, const RobotMessagePackageType message_type)
+    : timestamp_(timestamp), source_(source), message_type_(message_type)
+  {
+  }
   virtual ~RobotMessage() = default;
 
   /*!

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message.h
@@ -37,7 +37,7 @@ namespace primary_interface
 /*!
  * \brief Possible RobotMessage types
  */
-enum class RobotMessagePackageType : uint8_t
+enum class RobotMessagePackageType : int8_t
 {
   ROBOT_MESSAGE_TEXT = 0,
   ROBOT_MESSAGE_PROGRAM_LABEL = 1,
@@ -62,7 +62,7 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  RobotMessage(const uint64_t timestamp, const uint8_t source) : timestamp_(timestamp), source_(source)
+  RobotMessage(const uint64_t timestamp, const int8_t source) : timestamp_(timestamp), source_(source)
   {
   }
   virtual ~RobotMessage() = default;
@@ -94,7 +94,7 @@ public:
   virtual std::string toString() const;
 
   uint64_t timestamp_;
-  uint8_t source_;
+  int8_t source_;
   RobotMessagePackageType message_type_;
 };
 

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
@@ -34,6 +34,20 @@ namespace ur_driver
 {
 namespace primary_interface
 {
+enum class ReportLevel : int32_t
+{
+  DEBUG = 0,
+  INFO = 1,
+  WARNING = 2,
+  VIOLATION = 3,
+  FAULT = 4,
+  DEVL_DEBUG = 128,
+  DEVL_INFO = 129,
+  DEVL_WARNING = 130,
+  DEVL_VIOLATION = 131,
+  DEVL_FAULT = 132
+};
+
 /*!
  * \brief The ErrorCodeMessage class handles the error code messages sent via the primary UR interface.
  */
@@ -81,7 +95,7 @@ public:
 
   int32_t message_code_;
   int32_t message_argument_;
-  int32_t report_level_;
+  ReportLevel report_level_;
   uint8_t data_type_;
   uint32_t data_;
   std::string text_;

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/error_code_message.h
@@ -1,0 +1,83 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The ErrorCodeMessage class handles the error code messages sent via the primary UR interface.
+ */
+class ErrorCodeMessage : public RobotMessage
+{
+public:
+  ErrorCodeMessage() = delete;
+  /*!
+   * \brief Creates a new ErrorCodeMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  ErrorCodeMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_ERROR_CODE)
+  {
+  }
+  virtual ~ErrorCodeMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t message_code_;
+  int32_t message_argument_;
+  int32_t report_level_;
+  uint8_t data_type_;
+  uint32_t data_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/key_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/key_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/key_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/key_message.h
@@ -1,0 +1,82 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The KeyMessage class handles the key messages sent via the primary UR interface.
+ */
+class KeyMessage : public RobotMessage
+{
+public:
+  KeyMessage() = delete;
+  /*!
+   * \brief Creates a new KeyMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  KeyMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_KEY)
+  {
+  }
+  virtual ~KeyMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t message_code_;
+  int32_t message_argument_;
+  uint8_t title_size_;
+  std::string title_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/runtime_exception_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/runtime_exception_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/runtime_exception_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/runtime_exception_message.h
@@ -1,0 +1,80 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The RuntimeExceptionMessage class handles the runtime exception messages sent via the primary UR interface.
+ */
+class RuntimeExceptionMessage : public RobotMessage
+{
+public:
+  RuntimeExceptionMessage() = delete;
+  /*!
+   * \brief Creates a new RuntimeExceptionMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  RuntimeExceptionMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_RUNTIME_EXCEPTION)
+  {
+  }
+  virtual ~RuntimeExceptionMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t line_number_;
+  int32_t column_number_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/text_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/text_message.h
@@ -1,0 +1,78 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The TextMessage class handles the text messages sent via the primary UR interface.
+ */
+class TextMessage : public RobotMessage
+{
+public:
+  TextMessage() = delete;
+  /*!
+   * \brief Creates a new TextMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  TextMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_TEXT)
+  {
+  }
+  virtual ~TextMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/text_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/text_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/version_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/version_message.h
@@ -47,7 +47,7 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  VersionMessage(uint64_t timestamp, uint8_t source) : RobotMessage(timestamp, source)
+  VersionMessage(uint64_t timestamp, int8_t source) : RobotMessage(timestamp, source)
   {
   }
   virtual ~VersionMessage() = default;

--- a/ur_robot_driver/include/ur_robot_driver/primary/robot_message/version_message.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/robot_message/version_message.h
@@ -47,7 +47,8 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  VersionMessage(uint64_t timestamp, int8_t source) : RobotMessage(timestamp, source)
+  VersionMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_VERSION)
   {
   }
   virtual ~VersionMessage() = default;

--- a/ur_robot_driver/include/ur_robot_driver/ur/calibration_checker.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/calibration_checker.h
@@ -27,18 +27,17 @@
 #ifndef UR_RTDE_DRIVER_UR_CALIBRATION_CHECKER_H_INCLUDED
 #define UR_RTDE_DRIVER_UR_CALIBRATION_CHECKER_H_INCLUDED
 
-#include <ur_robot_driver/comm/pipeline.h>
-
+#include <ur_robot_driver/primary/primary_package_handler.h>
 #include <ur_robot_driver/primary/robot_state/kinematics_info.h>
 
 namespace ur_driver
 {
 /*!
- * \brief The CalibrationChecker class consumes primary packages ignoring all but KinematicsInfo
- * packages. These are then checked against the used kinematics to see if the correct calibration
- * is used.
+ * \brief The CalibrationChecker checks a received KinematicsInfo package against a registered calibration hash
+ * value. This way we know whether the robot that sent the KinematicsInfo package matches the
+ * expected calibration.
  */
-class CalibrationChecker : public comm::IConsumer<primary_interface::PrimaryPackage>
+class CalibrationChecker : public primary_interface::IPrimaryPackageHandler<primary_interface::KinematicsInfo>
 {
 public:
   /*!
@@ -51,31 +50,6 @@ public:
   virtual ~CalibrationChecker() = default;
 
   /*!
-   * \brief Empty setup function, as no setup is needed.
-   */
-  virtual void setupConsumer()
-  {
-  }
-  /*!
-   * \brief Tears down the consumer.
-   */
-  virtual void teardownConsumer()
-  {
-  }
-  /*!
-   * \brief Stops the consumer.
-   */
-  virtual void stopConsumer()
-  {
-  }
-  /*!
-   * \brief Handles timeouts.
-   */
-  virtual void onTimeout()
-  {
-  }
-
-  /*!
    * \brief Consumes a package, checking its hash if it is a KinematicsInfo package. If the hash
    * does not match the expected hash, an error is logged.
    *
@@ -83,7 +57,7 @@ public:
    *
    * \returns True, if the package was consumed correctly
    */
-  virtual bool consume(std::shared_ptr<primary_interface::PrimaryPackage> product);
+  virtual void handle(primary_interface::KinematicsInfo& kin_info) override;
 
   /*!
    * \brief Used to make sure the calibration check is not performed several times.

--- a/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/ur_driver.h
@@ -33,6 +33,7 @@
 #include "ur_robot_driver/ur/tool_communication.h"
 #include "ur_robot_driver/ur/version_information.h"
 #include "ur_robot_driver/primary/robot_message/version_message.h"
+#include "ur_robot_driver/primary/primary_client.h"
 #include "ur_robot_driver/rtde/rtde_writer.h"
 
 namespace ur_driver
@@ -165,7 +166,7 @@ public:
    *
    * \param checksum Hash of the used kinematics information
    */
-  void checkCalibration(const std::string& checksum);
+  //void checkCalibration(const std::string& checksum);
 
   /*!
    * \brief Getter for the RTDE writer used to write to the robot's RTDE interface.
@@ -211,8 +212,10 @@ private:
   std::unique_ptr<rtde_interface::RTDEClient> rtde_client_;
   std::unique_ptr<comm::ReverseInterface> reverse_interface_;
   std::unique_ptr<comm::ScriptSender> script_sender_;
-  std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> primary_stream_;
-  std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> secondary_stream_;
+
+  primary_interface::PrimaryClient primary_client_;
+  //std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> primary_stream_;
+  //std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> secondary_stream_;
 
   double servoj_time_;
   uint32_t servoj_gain_;

--- a/ur_robot_driver/src/primary/primary_client.cpp
+++ b/ur_robot_driver/src/primary/primary_client.cpp
@@ -1,0 +1,47 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <ur_robot_driver/primary/primary_client.h>
+#include <ur_robot_driver/primary/primary_shell_consumer.h>
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+PrimaryClient::PrimaryClient(const std::string& robot_ip) : robot_ip_(robot_ip)
+{
+  stream_.reset(new comm::URStream<PrimaryPackage>(robot_ip_, UR_PRIMARY_PORT));
+  producer_.reset(new comm::URProducer<PrimaryPackage>(*stream_, parser_));
+  producer_->setupProducer();
+
+  consumer_.reset(new PrimaryShellConsumer());
+
+  pipeline_.reset(new comm::Pipeline<PrimaryPackage>(*producer_, consumer_.get(), "primary pipeline", notifier_));
+  pipeline_->run();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
@@ -40,7 +40,9 @@ bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
 {
   bp.parse(message_code_);
   bp.parse(message_argument_);
-  bp.parse(report_level_);
+  int32_t report_level;
+  bp.parse(report_level);
+  report_level_ = static_cast<ReportLevel>(report_level);
   bp.parse(data_type_);
   bp.parse(data_);
   bp.parseRemainder(text_);
@@ -58,7 +60,7 @@ std::string ErrorCodeMessage::toString() const
   std::stringstream ss;
   ss << "Message code: " << message_code_ << std::endl;
   ss << "Message argument: " << message_argument_ << std::endl;
-  ss << "Report level: " << report_level_ << std::endl;
+  ss << "Report level: " << static_cast<int>(report_level_) << std::endl;
   ss << "Datatype: " << static_cast<int>(data_type_) << std::endl;
   ss << "Data: " << data_ << std::endl;
   ss << "Text: " << text_;

--- a/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_robot_driver/log.h"
 #include "ur_robot_driver/primary/robot_message/error_code_message.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
 
 namespace ur_driver
 {
@@ -45,6 +46,11 @@ bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool ErrorCodeMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string ErrorCodeMessage::toString() const

--- a/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/error_code_message.cpp
@@ -1,0 +1,62 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/error_code_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(message_code_);
+  bp.parse(message_argument_);
+  bp.parse(report_level_);
+  bp.parse(data_type_);
+  bp.parse(data_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string ErrorCodeMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Message code: " << message_code_ << std::endl;
+  ss << "Message argument: " << message_argument_ << std::endl;
+  ss << "Report level: " << report_level_ << std::endl;
+  ss << "Datatype: " << static_cast<int>(data_type_) << std::endl;
+  ss << "Data: " << data_ << std::endl;
+  ss << "Text: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/ur_robot_driver/src/primary/robot_message/key_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/key_message.cpp
@@ -1,0 +1,58 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2019-04-08
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/key_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool KeyMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(message_code_);
+  bp.parse(message_argument_);
+  bp.parse(title_size_);
+  bp.parse(title_, title_size_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string KeyMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Message code: " << message_code_ << std::endl;
+  ss << "Title: " << title_ << std::endl;
+  ss << "Text: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/ur_robot_driver/src/primary/robot_message/key_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/key_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_robot_driver/log.h"
 #include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
 
 namespace ur_driver
 {
@@ -44,6 +45,11 @@ bool KeyMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool KeyMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string KeyMessage::toString() const

--- a/ur_robot_driver/src/primary/robot_message/runtime_exception_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/runtime_exception_message.cpp
@@ -1,0 +1,56 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/runtime_exception_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool RuntimeExceptionMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(line_number_);
+  bp.parse(column_number_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string RuntimeExceptionMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Runtime error in line " << line_number_;
+  ss << ", column " << column_number_ << std::endl;
+  ss << "Error: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/ur_robot_driver/src/primary/robot_message/runtime_exception_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/runtime_exception_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_robot_driver/log.h"
 #include "ur_robot_driver/primary/robot_message/runtime_exception_message.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
 
 namespace ur_driver
 {
@@ -42,6 +43,11 @@ bool RuntimeExceptionMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool RuntimeExceptionMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string RuntimeExceptionMessage::toString() const

--- a/ur_robot_driver/src/primary/robot_message/text_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/text_message.cpp
@@ -1,0 +1,50 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2019-04-08
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/text_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool TextMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string TextMessage::toString() const
+{
+  return text_;
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/ur_robot_driver/src/primary/robot_message/text_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/text_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_robot_driver/log.h"
 #include "ur_robot_driver/primary/robot_message/text_message.h"
+#include "ur_robot_driver/primary/abstract_primary_consumer.h"
 
 namespace ur_driver
 {
@@ -40,6 +41,11 @@ bool TextMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool TextMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string TextMessage::toString() const

--- a/ur_robot_driver/src/primary/robot_message/version_message.cpp
+++ b/ur_robot_driver/src/primary/robot_message/version_message.cpp
@@ -49,7 +49,7 @@ bool VersionMessage::parseWith(comm::BinParser& bp)
   return true;  // not really possible to check dynamic size packets
 }
 
-bool VersionMessage ::consumeWith(AbstractPrimaryConsumer& consumer)
+bool VersionMessage::consumeWith(AbstractPrimaryConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/ur_robot_driver/src/ur/calibration_checker.cpp
+++ b/ur_robot_driver/src/ur/calibration_checker.cpp
@@ -20,30 +20,23 @@ CalibrationChecker::CalibrationChecker(const std::string& expected_hash)
   : expected_hash_(expected_hash), checked_(false)
 {
 }
-bool CalibrationChecker::consume(std::shared_ptr<primary_interface::PrimaryPackage> product)
+void CalibrationChecker::handle(primary_interface::KinematicsInfo& kin_info)
 {
-  auto kin_info = std::dynamic_pointer_cast<primary_interface::KinematicsInfo>(product);
-  if (kin_info != nullptr)
+  if (kin_info.toHash() != expected_hash_)
   {
-    // LOG_INFO("%s", product->toString().c_str());
-    //
-    if (kin_info->toHash() != expected_hash_)
-    {
-      LOG_ERROR("The calibration parameters of the connected robot don't match the ones from the given kinematics "
-                "config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the "
-                "ur_calibration tool to extract the correct calibration from the robot and pass that into the "
-                "description. See "
-                "[https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for "
-                "details.");
-    }
-    else
-    {
-      LOG_INFO("Calibration checked successfully.");
-    }
-
-    checked_ = true;
+    LOG_ERROR("The calibration parameters of the connected robot don't match the ones from the given kinematics "
+              "config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the "
+              "ur_calibration tool to extract the correct calibration from the robot and pass that into the "
+              "description. See "
+              "[https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for "
+              "details.");
+  }
+  else
+  {
+    LOG_INFO("Calibration checked successfully.");
   }
 
-  return true;
+  checked_ = true;
 }
+
 }  // namespace ur_driver


### PR DESCRIPTION
This branch will
 - Add a full primary client object structure to the client
 - Read more data from the primary interface
 - Give users output when script code sent to the primary interface gets started and finishes as requested in #163, #118, #19, #40 which will hopefully help with #131 #77
 - Show users when they send malformed script code to the robot
 - Inform users when they are trying to send script code to an e-Series robot which is not in remote control mode
 - Output any error messages coming up on the robot

I am not sure yet, to which extent all of those things will be tackled in this MR, but it will definitely be a start from which such features could easily be implemented.