### PR TITLE
Initialize member variables

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/ros/robot_state_helper.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/robot_state_helper.h
@@ -59,6 +59,7 @@ public:
   virtual ~RobotStateHelper() = default;
 
 private:
+  ros::NodeHandle nh_;
   void robotModeCallback(const ur_dashboard_msgs::RobotMode& msg);
   void safetyModeCallback(const ur_dashboard_msgs::SafetyMode& msg);
 
@@ -85,8 +86,9 @@ private:
   // Action server functions
   void setModeGoalCallback();
   void setModePreemptCallback();
+  void startActionServer();
+  bool is_started_;
 
-  ros::NodeHandle nh_;
   RobotMode robot_mode_;
   SafetyMode safety_mode_;
 

--- a/ur_robot_driver/include/ur_robot_driver/ur/datatypes.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/datatypes.h
@@ -33,6 +33,7 @@ namespace ur_driver
 {
 enum class RobotMode : int8_t
 {
+  UNKNOWN = -128,  // This is not defined by UR but only inside this driver
   NO_CONTROLLER = -1,
   DISCONNECTED = 0,
   CONFIRM_SAFETY = 1,

--- a/ur_robot_driver/src/ros/robot_state_helper.cpp
+++ b/ur_robot_driver/src/ros/robot_state_helper.cpp
@@ -57,6 +57,7 @@ RobotStateHelper::RobotStateHelper(const ros::NodeHandle& nh)
   // Service to start UR program execution on the robot
   play_program_srv_ = nh_.serviceClient<std_srvs::Trigger>("dashboard/play");
 
+  play_program_srv_.waitForExistence();
   set_mode_as_.registerGoalCallback(std::bind(&RobotStateHelper::setModeGoalCallback, this));
   set_mode_as_.registerPreemptCallback(std::bind(&RobotStateHelper::setModePreemptCallback, this));
 }

--- a/ur_robot_driver/src/ros/robot_state_helper.cpp
+++ b/ur_robot_driver/src/ros/robot_state_helper.cpp
@@ -30,7 +30,11 @@
 #include <std_srvs/Trigger.h>
 namespace ur_driver
 {
-RobotStateHelper::RobotStateHelper(const ros::NodeHandle& nh) : nh_(nh), set_mode_as_(nh_, "set_mode", false)
+RobotStateHelper::RobotStateHelper(const ros::NodeHandle& nh)
+  : nh_(nh)
+  , robot_mode_(RobotMode::POWER_OFF)
+  , safety_mode_(SafetyMode::UNDEFINED_SAFETY_MODE)
+  , set_mode_as_(nh_, "set_mode", false)
 {
   // Topic on which the robot_mode is published by the driver
   robot_mode_sub_ = nh_.subscribe("robot_mode", 1, &RobotStateHelper::robotModeCallback, this);


### PR DESCRIPTION
It can happen that the action gets triggered before the mode callback got triggered which will lead to a crash of the helper. (See #176)

While this changes stops the helper from crashing when this happens, it might
not be the best idea to do so as the question remains, what we should do
if we haven't even received a current status from the robot.

With the changes introduced inside this commit, the helper would trigger the
respective state changes, which might lead to wrong requests if we aren't entirely
sure what to do.

One solution would be to reject goals as long as no status was received,
but that would break such scenarios where you want to activate the robot automatically
during startup.

Another idea would be to delay actually starting the action server until we
received both, robot mode and safety mode. But I am not entirely sure whether
this will scale well.