### PR TITLE
robot_driver: use pass_all_args to reduce verbosity

### DIFF
--- a/ur_robot_driver/launch/ur10_bringup.launch
+++ b/ur_robot_driver/launch/ur10_bringup.launch
@@ -13,20 +13,7 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true">
     <arg name="use_tool_communication" value="false"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
   </include>
-
 </launch>

--- a/ur_robot_driver/launch/ur10e_bringup.launch
+++ b/ur_robot_driver/launch/ur10e_bringup.launch
@@ -23,28 +23,5 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
-    <arg name="use_tool_communication" value="$(arg use_tool_communication)"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
-    <arg name="tool_voltage" value="$(arg tool_voltage)"/>
-    <arg name="tool_parity" value="$(arg tool_parity)"/>
-    <arg name="tool_baud_rate" value="$(arg tool_baud_rate)"/>
-    <arg name="tool_stop_bits" value="$(arg tool_stop_bits)"/>
-    <arg name="tool_rx_idle_chars" value="$(arg tool_rx_idle_chars)"/>
-    <arg name="tool_tx_idle_chars" value="$(arg tool_tx_idle_chars)"/>
-    <arg name="tool_device_name" value="$(arg tool_device_name)"/>
-    <arg name="tool_tcp_port" value="$(arg tool_tcp_port)"/>
-  </include>
-
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true"/>
 </launch>

--- a/ur_robot_driver/launch/ur3_bringup.launch
+++ b/ur_robot_driver/launch/ur3_bringup.launch
@@ -13,20 +13,7 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true">
     <arg name="use_tool_communication" value="false"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
   </include>
-
 </launch>

--- a/ur_robot_driver/launch/ur3e_bringup.launch
+++ b/ur_robot_driver/launch/ur3e_bringup.launch
@@ -22,28 +22,5 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
-    <arg name="use_tool_communication" value="$(arg use_tool_communication)"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
-    <arg name="tool_voltage" value="$(arg tool_voltage)"/>
-    <arg name="tool_parity" value="$(arg tool_parity)"/>
-    <arg name="tool_baud_rate" value="$(arg tool_baud_rate)"/>
-    <arg name="tool_stop_bits" value="$(arg tool_stop_bits)"/>
-    <arg name="tool_rx_idle_chars" value="$(arg tool_rx_idle_chars)"/>
-    <arg name="tool_tx_idle_chars" value="$(arg tool_tx_idle_chars)"/>
-    <arg name="tool_device_name" value="$(arg tool_device_name)"/>
-    <arg name="tool_tcp_port" value="$(arg tool_tcp_port)"/>
-  </include>
-
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true"/>
 </launch>

--- a/ur_robot_driver/launch/ur5_bringup.launch
+++ b/ur_robot_driver/launch/ur5_bringup.launch
@@ -13,20 +13,7 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true">
     <arg name="use_tool_communication" value="false"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
   </include>
-
 </launch>

--- a/ur_robot_driver/launch/ur5e_bringup.launch
+++ b/ur_robot_driver/launch/ur5e_bringup.launch
@@ -22,28 +22,5 @@
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
 
-  <include file="$(find ur_robot_driver)/launch/ur_common.launch">
-    <arg name="debug" value="$(arg debug)"/>
-    <arg name="use_tool_communication" value="$(arg use_tool_communication)"/>
-    <arg name="controller_config_file" value="$(arg controller_config_file)"/>
-    <arg name="robot_description_file" value="$(arg robot_description_file)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-    <arg name="robot_ip" value="$(arg robot_ip)"/>
-    <arg name="reverse_port" value="$(arg reverse_port)"/>
-    <arg name="script_sender_port" value="$(arg script_sender_port)"/>
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
-    <arg name="controllers" value="$(arg controllers)"/>
-    <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>
-    <arg name="headless_mode" value="$(arg headless_mode)"/>
-    <arg name="tool_voltage" value="$(arg tool_voltage)"/>
-    <arg name="tool_parity" value="$(arg tool_parity)"/>
-    <arg name="tool_baud_rate" value="$(arg tool_baud_rate)"/>
-    <arg name="tool_stop_bits" value="$(arg tool_stop_bits)"/>
-    <arg name="tool_rx_idle_chars" value="$(arg tool_rx_idle_chars)"/>
-    <arg name="tool_tx_idle_chars" value="$(arg tool_tx_idle_chars)"/>
-    <arg name="tool_device_name" value="$(arg tool_device_name)"/>
-    <arg name="tool_tcp_port" value="$(arg tool_tcp_port)"/>
-  </include>
-
+  <include file="$(find ur_robot_driver)/launch/ur_common.launch" pass_all_args="true" />
 </launch>


### PR DESCRIPTION
As per subject.

Note: I haven't tested this (as in: started the driver), but I expect it to work as described.
