### PR TITLE
Fix variable type checking in rtde_client

### DIFF
--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -199,7 +199,6 @@ void RTDEClient::setupOutputs(const uint16_t protocol_version)
       for (std::size_t i = 0; i < variable_types.size(); ++i)
       {
         LOG_DEBUG("%s confirmed as datatype: %s", output_recipe_[i].c_str(), variable_types[i].c_str());
-        return;
         if (variable_types[i] == "NOT_FOUND")
         {
           std::string message = "Variable '" + output_recipe_[i] +
@@ -207,6 +206,7 @@ void RTDEClient::setupOutputs(const uint16_t protocol_version)
           throw UrException(message);
         }
       }
+      return;
     }
     else
     {


### PR DESCRIPTION
I am not completely sure this is correct, but the previous placement looks like a bug