### PR TITLE
WIP: make variables global

### DIFF
--- a/ur_robot_driver/resources/ros_control.urscript
+++ b/ur_robot_driver/resources/ros_control.urscript
@@ -3,7 +3,7 @@
 global steptime = get_steptime()
 
 textmsg("steptime=", steptime)
-global MULT_jointstate = {{JOINT_STATE_REPLACE}}
+MULT_jointstate = {{JOINT_STATE_REPLACE}}
 
 #Constants
 global SERVO_UNINITIALIZED = -1

--- a/ur_robot_driver/resources/ros_control.urscript
+++ b/ur_robot_driver/resources/ros_control.urscript
@@ -1,20 +1,20 @@
 {{BEGIN_REPLACE}}
 
-steptime = get_steptime()
+global steptime = get_steptime()
 
 textmsg("steptime=", steptime)
-MULT_jointstate = {{JOINT_STATE_REPLACE}}
+global MULT_jointstate = {{JOINT_STATE_REPLACE}}
 
 #Constants
-SERVO_UNINITIALIZED = -1
-SERVO_IDLE = 0
-SERVO_RUNNING = 1
+global SERVO_UNINITIALIZED = -1
+global SERVO_IDLE = 0
+global SERVO_RUNNING = 1
 
-MODE_STOPPED = -2
-MODE_UNINITIALIZED = -1
-MODE_IDLE = 0
-MODE_SERVOJ = 1
-MODE_SPEEDJ = 2
+global MODE_STOPPED = -2
+global MODE_UNINITIALIZED = -1
+global MODE_IDLE = 0
+global MODE_SERVOJ = 1
+global MODE_SPEEDJ = 2
 
 #Global variables are also showed in the Teach pendants variable list
 global cmd_servo_state = SERVO_UNINITIALIZED


### PR DESCRIPTION
Explicitly state globals (then also works when within function).
This change enables to have more than one node in the ur-program.
Closely relates to https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/issues/5 and https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/pull/7

Quoting the scriptmanual_en.pdf, section 1.7 (p. 6):
>Every variable declared inside a program exits at a global scope, except when they
are declared inside a function. In that case the variable are local to that function. Two
qualifiers are available to modify this behaviour. The local qualifier tells the runtime to
treat a variable inside a function, as being truly local, even if a global variable with the
same name exists. The global qualifier forces a variable declared inside a function,
to be globally accessible.