### PR TITLE
driver: use default rates for JTC goal monitor rates.

### DIFF
--- a/ur_robot_driver/config/ur10_controllers.yaml
+++ b/ur_robot_driver/config/ur10_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,7 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -73,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -84,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -93,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -110,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -121,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -130,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/ur_robot_driver/config/ur10e_controllers.yaml
+++ b/ur_robot_driver/config/ur10e_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,7 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -73,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -84,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -93,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -110,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -121,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -130,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,8 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
-
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -74,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -85,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -94,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -111,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -122,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -131,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/ur_robot_driver/config/ur3e_controllers.yaml
+++ b/ur_robot_driver/config/ur3e_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,7 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -73,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -84,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -93,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -110,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -121,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -130,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/ur_robot_driver/config/ur5_controllers.yaml
+++ b/ur_robot_driver/config/ur5_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,7 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -73,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -84,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -93,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -110,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -121,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -130,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/ur_robot_driver/config/ur5e_controllers.yaml
+++ b/ur_robot_driver/config/ur5e_controllers.yaml
@@ -43,7 +43,7 @@ scaled_pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 pos_traj_controller:
    type: position_controllers/JointTrajectoryController
@@ -59,7 +59,7 @@ pos_traj_controller:
       wrist_3_joint: {trajectory: 0.2, goal: 0.1}
    stop_trajectory_duration: 0.5
    state_publish_rate: *loop_hz
-   action_monitor_rate: 10
+   action_monitor_rate: 20
 
 scaled_vel_traj_controller:
    type: velocity_controllers/ScaledJointTrajectoryController
@@ -73,9 +73,6 @@ scaled_vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -84,7 +81,6 @@ scaled_vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -93,10 +89,9 @@ scaled_vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 vel_traj_controller:
    type: velocity_controllers/JointTrajectoryController
@@ -110,9 +105,6 @@ vel_traj_controller:
       wrist_1_joint: {trajectory: 0.1, goal: 0.1}
       wrist_2_joint: {trajectory: 0.1, goal: 0.1}
       wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate:  *loop_hz
-   action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
       shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
@@ -121,7 +113,6 @@ vel_traj_controller:
       wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
       wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-
    # Use a feedforward term to reduce the size of PID gains
    velocity_ff:
       shoulder_pan_joint: 1.0
@@ -130,10 +121,9 @@ vel_traj_controller:
       wrist_1_joint: 1.0
       wrist_2_joint: 1.0
       wrist_3_joint: 1.0
-
-   # state_publish_rate:  50 # Defaults to 50
-   # action_monitor_rate: 20 # Defaults to 20
-   #stop_trajectory_duration: 0 # Defaults to 0.0
+   stop_trajectory_duration: 0.5
+   state_publish_rate: *loop_hz
+   action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:


### PR DESCRIPTION
As per subject.

See the commit comment for some rationale.

Note: the `state_publish_rate` has been left to be equal to the `loop_hz`, as this controls how often the internal (position/velocity/effort) controller of the JTC publishes its state (ie: tracking error, target position, etc). That is something which *should* be published at the same rate the controller is run to actually be useful.
