### PR TITLE
Install resources directory

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -150,7 +150,7 @@ install(TARGETS ur_robot_driver ur_robot_driver_plugin ur_robot_driver_node robo
 install(PROGRAMS scripts/tool_communication
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-install(DIRECTORY config launch
+install(DIRECTORY config launch resources
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 


### PR DESCRIPTION
Installing the resources folder was missing. Installing it as suggested by @gavanderhoorn in #201 

I was considering only installing the recipe and urscript file and not the complete folder, as this also contains the urcap installation files. My reasoning was that a full installation should also contain those. 

On the other hand users probably won't grab them out of `/opt/ros/distro/share/ur_robot_driver/resources` once there is a binary installation available.

Any opinions on this?

Closes #201