### PR TITLE
Use Robot_hw_nh node handle for joints.

### DIFF
--- a/ur_robot_driver/config/ur10_controllers.yaml
+++ b/ur_robot_driver/config/ur10_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 125
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/config/ur10e_controllers.yaml
+++ b/ur_robot_driver/config/ur10e_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 500
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 125
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/config/ur3e_controllers.yaml
+++ b/ur_robot_driver/config/ur3e_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 500
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/config/ur5_controllers.yaml
+++ b/ur_robot_driver/config/ur5_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 125
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/config/ur5e_controllers.yaml
+++ b/ur_robot_driver/config/ur5e_controllers.yaml
@@ -3,7 +3,7 @@ hardware_control_loop:
    loop_hz: &loop_hz 500
 
 # Settings for ros_control hardware interface
-hardware_interface:
+ur_hardware_interface:
    joints: &robot_joints
      - shoulder_pan_joint
      - shoulder_lift_joint

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -280,7 +280,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // Names of the joints. Usually, this is given in the controller config file.
   if (!robot_hw_nh.getParam("joints", joint_names_))
   {
-    ROS_ERROR_STREAM("Cannot find required parameter " << root_nh.resolveName("hardware_interface/joints")
+    ROS_ERROR_STREAM("Cannot find required parameter " << robot_hw_nh.resolveName("joints")
                                                        << " on the parameter server.");
     throw std::runtime_error("Cannot find required parameter "
                              "'controller_joint_names' on the parameter server.");

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -278,7 +278,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   command_sub_ = robot_hw_nh.subscribe("script_command", 1, &HardwareInterface::commandCallback, this);
 
   // Names of the joints. Usually, this is given in the controller config file.
-  if (!root_nh.getParam("hardware_interface/joints", joint_names_))
+  if (!robot_hw_nh.getParam("joints", joint_names_))
   {
     ROS_ERROR_STREAM("Cannot find required parameter " << root_nh.resolveName("hardware_interface/joints")
                                                        << " on the parameter server.");


### PR DESCRIPTION
Modified hardware interface to look for joints parameter under the robot_hw node handle. By doing this, removing the hardware_interface prefixed namespace and just having joints as the parameter name, I have managed to get this working well with both a combined robot hardware interface with 2 arms under the same controller manager and with a single arm as is usual.

Similar to pr #110 but does not require the addition of another param. Does modify the hardware_interface param in the controller yamls to be ur_hardware_interface. But after testing and looking at source it seems only the joints parameter references that name.