### PR TITLE
Changed network in Industrial CI pipeline

### DIFF
--- a/.github/dockerursim/build_and_run_docker_ursim.sh
+++ b/.github/dockerursim/build_and_run_docker_ursim.sh
@@ -2,11 +2,14 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+docker network create --subnet=192.168.0.0/16 static_test_net
 
 docker build ${DIR} -t mydockerursim
 docker volume create dockerursim
 docker run --name="mydockerursim" -d \
   -e ROBOT_MODEL=UR5 \
+  --net static_test_net \
+  --ip 192.168.56.101 \
   -p 8080:8080 \
   -p 29999:29999 \
   -p 30001-30004:30001-30004 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
           - ROS_DISTRO: kinetic
             UPSTREAM_WORKSPACE: .ci.rosinstall
             ROS_REPO: main
-            DOCKER_RUN_OPTS: --network bridge
-            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 172.17.0.2'
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             IMMEDIATE_TEST_OUTPUT: true
           - ROS_DISTRO: melodic
             UPSTREAM_WORKSPACE: .ci.rosinstall
             ROS_REPO: main
-            DOCKER_RUN_OPTS: --network bridge
-            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 172.17.0.2'
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             IMMEDIATE_TEST_OUTPUT: true
 
     steps:

--- a/ur_robot_driver/test/driver.test
+++ b/ur_robot_driver/test/driver.test
@@ -5,7 +5,7 @@
     -->
 
   <include file="$(find ur_robot_driver)/launch/ur5e_bringup.launch">
-    <arg name="robot_ip" value="192.168.56.101"/>
+    <arg name="robot_ip" value="192.168.56.103"/>
     <arg name="headless_mode" value="true"/>
   </include>
 

--- a/ur_robot_driver/test/driver.test
+++ b/ur_robot_driver/test/driver.test
@@ -5,7 +5,7 @@
     -->
 
   <include file="$(find ur_robot_driver)/launch/ur5e_bringup.launch">
-    <arg name="robot_ip" value="192.168.56.103"/>
+    <arg name="robot_ip" value="172.17.0.2"/>
     <arg name="headless_mode" value="true"/>
   </include>
 

--- a/ur_robot_driver/test/driver.test
+++ b/ur_robot_driver/test/driver.test
@@ -5,7 +5,7 @@
     -->
 
   <include file="$(find ur_robot_driver)/launch/ur5e_bringup.launch">
-    <arg name="robot_ip" value="172.17.0.2"/>
+    <arg name="robot_ip" value="192.168.56.101"/>
     <arg name="headless_mode" value="true"/>
   </include>
 

--- a/ur_robot_driver/test/test_rtde_client.cpp
+++ b/ur_robot_driver/test/test_rtde_client.cpp
@@ -18,7 +18,7 @@
 
 using namespace ur_driver;
 
-const std::string ROBOT_IP = "172.17.0.2";
+const std::string ROBOT_IP = "192.168.56.101";
 
 TEST(UrRobotDriver, rtde_handshake)
 {


### PR DESCRIPTION
This Pull-Request contains changes to the network used in Industrial CI pipeline and the static IPs used in the tests.

This Pull-Request moves away from using the default Docker network in the range 172.17.0.0/16, since a specific IP cannot be chosen/guaranteed within this range. Instead, a network is now created with range 192.168.0.0/16, which allows for assigning specific IPs to the containers.
