### PR TITLE
readme: improve consistency between play & stop buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ For more information on the launch file's parameters see its own documentation.
 
 Once the robot driver is started, load the [previously generated program](#prepare-the-robot) on the
 robot panel that will start the *External Control* program node and execute it. From that moment on
-the robot is fully functional. You can make use of the *Pause* function or even *Stop* (◾) the
-program.  Simply press the *Play* button (▶) again and the ROS driver will reconnect.
+the robot is fully functional. You can make use of the *Pause* function or even *Stop* (:stop_button:) the
+program.  Simply press the *Play* button (:arrow_forward:) again and the ROS driver will reconnect.
 
 Inside the ROS terminal running the driver you should see the output `Robot ready to receive control commands.`
 


### PR DESCRIPTION
As per subject.

Instead of using unicode characters directly, use textual emoji names (from [this list](https://github.com/ikatyang/emoji-cheat-sheet#av-symbol)).

This renders more consistently for me in several browsers (Firefox, Edge, etc) on both Windows and Linux (haven't checked OSX).

The previous icons were black (play) and blue (stop) for me, with inconsistent styles.
