### PR TITLE
Use catkin_install_python macro for python files

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -123,7 +123,7 @@ install(TARGETS ur_robot_driver_plugin ur_robot_driver_node robot_state_helper d
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(PROGRAMS scripts/tool_communication
+catkin_install_python(PROGRAMS scripts/tool_communication
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY config launch resources


### PR DESCRIPTION
This macro works just like the normal `install` macro, but it also automatically changes the shebang line in the python file to `python2` or `python3`, depending which version is used.

See: http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

What this means is that this package can be used with Python3 without
any further changes, for example in ROS Noetic.