### PR TITLE
Replace two logging macros with ROS logging macros.

### DIFF
--- a/ur_calibration/src/calibration_consumer.cpp
+++ b/ur_calibration/src/calibration_consumer.cpp
@@ -38,7 +38,7 @@ bool CalibrationConsumer::consume(std::shared_ptr<urcl::primary_interface::Prima
   auto kin_info = std::dynamic_pointer_cast<urcl::primary_interface::KinematicsInfo>(product);
   if (kin_info != nullptr)
   {
-    LOG_INFO("%s", product->toString().c_str());
+    ROS_INFO("%s", product->toString().c_str());
     DHRobot my_robot;
     for (size_t i = 0; i < kin_info->dh_a_.size(); ++i)
     {

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -868,7 +868,7 @@ bool HardwareInterface::setIO(ur_msgs::SetIORequest& req, ur_msgs::SetIOResponse
   }
   else
   {
-    LOG_ERROR("Cannot execute function %u. This is not (yet) supported.", req.fun);
+    ROS_ERROR("Cannot execute function %u. This is not (yet) supported.", req.fun);
     res.success = false;
   }
 


### PR DESCRIPTION
Inside the driver we want to use plain ROS logging instead of the library's logging macros.