### PR TITLE
Adding reset revolution counter service (#325)

### DIFF
--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -760,6 +760,10 @@ Setup the mounted payload through a ROS service
 
 Calling this service will zero the robot's ftsensor. Note: On e-Series robots this will only work when the robot is in remote-control mode.
 
+##### reset_revolution_counter ([std_srvs/Trigger](http://docs.ros.org/api/std_srvs/html/srv/Trigger.html))
+
+Calling this service will reset the revolution counter for the robot's wrist_3_link. Note: On e-Series robots this will only work when the robot is in remote-control mode.
+
 #### Parameters
 
 ##### dashboard/receive_timeout (Required)

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -200,6 +200,7 @@ protected:
   bool setIO(ur_msgs::SetIORequest& req, ur_msgs::SetIOResponse& res);
   bool resendRobotProgram(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   bool zeroFTSensor(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
+  bool resetRevolutionCounter(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   void commandCallback(const std_msgs::StringConstPtr& msg);
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
@@ -215,6 +216,7 @@ protected:
 
   ros::ServiceServer deactivate_srv_;
   ros::ServiceServer tare_sensor_srv_;
+  ros::ServiceServer reset_revolution_counter_srv_;
   ros::ServiceServer set_payload_srv_;
 
   hardware_interface::JointStateInterface js_interface_;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -384,6 +384,10 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // work when the robot is in remote-control mode.
   tare_sensor_srv_ = robot_hw_nh.advertiseService("zero_ftsensor", &HardwareInterface::zeroFTSensor, this);
 
+  // Calling this service will reset the revolution counter for the robot's wrist_3_link. Note: On e-Series robots this will only
+  // work when the robot is in remote-control mode.
+  reset_revolution_counter_srv_ = robot_hw_nh.advertiseService("reset_revolution_counter", &HardwareInterface::resetRevolutionCounter, this);
+
   ur_driver_->startRTDECommunication();
   ROS_INFO_STREAM_NAMED("hardware_interface", "Loaded ur_robot_driver hardware_interface");
 
@@ -909,6 +913,15 @@ bool HardwareInterface::zeroFTSensor(std_srvs::TriggerRequest& req, std_srvs::Tr
 end
 )");
   }
+  return true;
+}
+
+bool HardwareInterface::resetRevolutionCounter(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res)
+{
+  res.success = this->ur_driver_->sendScript(R"(sec resetRevolutionCounter():
+  reset_revolution_counter()
+end
+)");
   return true;
 }
 


### PR DESCRIPTION
Hi,

I am trying to implement the service to reset the revolution counter of the robot's wrist_3_link. However, I am having a problem with the behavior of the script.

If I send the script as a secondary program:
```
sec resetRevolutionCounter():
  reset_revolution_counter()
end
```
It does not work as intended, the wrist_3_link gives a full rotation at full speed, which is not desirable at all, but on top of that, the counter is not reset. 

On the other hand, if I send the script just as:
```
reset_revolution_counter()
```

It does work as intended with the caveat that the driver's program is stopped and has to be reconnected in order to send any new command.

I think that the best solution would be to be able to reset the counter without disconnecting the main driver's program. Similarly to the behavior of the `zero_ftsensor` service. 

I would appreciate any suggestions on what I may be doing wrong.