### PR TITLE
Remove manual keepalive message from script

### DIFF
--- a/ur_robot_driver/resources/ros_control.urscript
+++ b/ur_robot_driver/resources/ros_control.urscript
@@ -103,7 +103,6 @@ textmsg("ExternalControl: External control active")
 keepalive = params_mult[1]
 while keepalive > 0 and control_mode > MODE_STOPPED:
   enter_critical
-  socket_send_line(1, "reverse_socket")
   params_mult = socket_read_binary_integer(1+6+1, "reverse_socket", 0.02) # steptime could work as well, but does not work in simulation
   if params_mult[0] > 0:
     keepalive = params_mult[1]


### PR DESCRIPTION
This is actually not properly checked by the driver, as keepalive signals
won't be sent when the program is paused.

When https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/46 will be merged, this line will cause a warning in each control cycle. Without https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/46 merged, this effectively doesn't change anything.