### PR TITLE
Optionally load robot description

### DIFF
--- a/ur_robot_driver/launch/ur_common.launch
+++ b/ur_robot_driver/launch/ur_common.launch
@@ -21,12 +21,15 @@
   <arg name="robot_description_file" doc="Robot description launch file."/>
   <arg name="limited" default="false" doc="Use the description in limited mode (Every axis rotates from -PI to PI)"/>
   <arg name="headless_mode" default="false" doc="Automatically send URScript to robot to execute. On e-Series this does require the robot to be in 'remote-control' mode. With this, the URCap is not needed on the robot."/>
+  <arg name="load_robot_description" default="true" doc="Whether to load robot description to the parameter server. If a custom urdf model is used, this parameter is set to false." />
 
   <!-- robot model -->
-  <include file="$(arg robot_description_file)">
-    <arg name="limited" value="$(arg limited)"/>
-    <arg name="kinematics_config" value="$(arg kinematics_config)"/>
-  </include>
+  <group if="$(arg load_robot_description)">
+    <include file="$(arg robot_description_file)">
+      <arg name="limited" value="$(arg limited)"/>
+      <arg name="kinematics_config" value="$(arg kinematics_config)"/>
+    </include>
+  </group>
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>


### PR DESCRIPTION
Hello,

I would like to propose a parameter to optionally load the robot_description  in ```ur_common.launch```.
I'm not completely sure if it is necessary, but it might help to prevent confusion if ```robot_description``` has been loaded previously or somewhere else with custom dh configuration. Other robot drivers have this option as well (e.g. [Pilz](https://github.com/PilzDE/pilz_robots/blob/noetic-devel/prbt_support/launch/robot.launch) )