### PR TITLE
Replace kinetic with noetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,25 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - ROS_DISTRO: kinetic
-            ROS_REPO: main
-            UPSTREAM_WORKSPACE: .ci.rosinstall
-            DOCKER_RUN_OPTS: --network static_test_net
-            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
-            IMMEDIATE_TEST_OUTPUT: true
           - ROS_DISTRO: melodic
             ROS_REPO: main
             UPSTREAM_WORKSPACE: .ci.rosinstall
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             IMMEDIATE_TEST_OUTPUT: true
-          - ROS_DISTRO: kinetic
+          - ROS_DISTRO: noetic
+            ROS_REPO: main
+            UPSTREAM_WORKSPACE: .ci.rosinstall
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
+            IMMEDIATE_TEST_OUTPUT: true
+          - ROS_DISTRO: melodic
             ROS_REPO: testing
             UPSTREAM_WORKSPACE: .ci.rosinstall
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             IMMEDIATE_TEST_OUTPUT: true
-          - ROS_DISTRO: melodic
+          - ROS_DISTRO: noetic
             ROS_REPO: testing
             UPSTREAM_WORKSPACE: .ci.rosinstall
             DOCKER_RUN_OPTS: --network static_test_net


### PR DESCRIPTION
Since ROS kinetic reached EOL we can remove the tests for kinetic from this repo

Simultaneously, we should add those for noetic, as there are users for noetic
already.