### PR TITLE
Add build notice about ROS noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This repository contains the new **ur_robot_driver** and a couple of helper pack
 
 ## Requirements
 This driver requires a system setup with ROS. It is recommended to use **Ubuntu 18.04 with ROS
-melodic**, however using Ubuntu 16.04 with ROS kinetic should also work.
+melodic**, however using Ubuntu 20.04 with ROS noetic should also work.
 
 To make sure that robot control isn't affected by system latencies, it is highly recommended to use
 a real-time kernel with the system. See the [real-time setup guide](ur_robot_driver/doc/real_time.md)
@@ -164,6 +164,18 @@ $ rosdep install --from-paths src --ignore-src -y
 $ catkin_make_isolated
 $ source devel_isolated/setup.bash
 ```
+
+### Note for noetic users
+If you are using ROS noetic, make sure to also clone [`ur_msgs`](https://github.com/ros-industrial/ur_msgs) to your workspace as it is currently not released for ROS noetic (see https://github.com/ros-industrial/ur_msgs/issues/13).
+```
+$ git clone https://github.com/ros-industrial/ur_msgs.git src/ur_msgs
+```
+
+Otherwise you will get build errors such as 
+```
+error: ‘ur_msgs::SetPayload::Request {aka struct ur_msgs::SetPayloadRequest_<std::allocator<void> >}’ has no member named ‘center_of_gravity’
+```
+
 
 ## Setting up a UR robot for ur_robot_driver
 ### Prepare the robot


### PR DESCRIPTION
As `ur_msgs` is not yet released for ROS noetic a notice on how to add this to the local workspace is added to the toplevel README file.

This came up in #385 and #384