### PR TITLE
Cartesian control

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(catkin REQUIRED
     trajectory_msgs
     ur_dashboard_msgs
     ur_msgs
-    twist_controller
     pass_through_controllers
     kdl_parser
 )
@@ -60,7 +59,6 @@ catkin_package(
     tf2_geometry_msgs
     tf2_msgs
     trajectory_msgs
-    twist_controller
     ur_dashboard_msgs
     ur_msgs
   DEPENDS

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(catkin REQUIRED
     trajectory_msgs
     ur_dashboard_msgs
     ur_msgs
+    twist_controller
     pass_through_controllers
     kdl_parser
 )
@@ -59,6 +60,7 @@ catkin_package(
     tf2_geometry_msgs
     tf2_msgs
     trajectory_msgs
+    twist_controller
     ur_dashboard_msgs
     ur_msgs
   DEPENDS

--- a/ur_robot_driver/config/ur10_controllers.yaml
+++ b/ur_robot_driver/config/ur10_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur10e_controllers.yaml
+++ b/ur_robot_driver/config/ur10e_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur16e_controllers.yaml
+++ b/ur_robot_driver/config/ur16e_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur3e_controllers.yaml
+++ b/ur_robot_driver/config/ur3e_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur5_controllers.yaml
+++ b/ur_robot_driver/config/ur5_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/config/ur5e_controllers.yaml
+++ b/ur_robot_driver/config/ur5e_controllers.yaml
@@ -138,6 +138,28 @@ forward_cartesian_traj_controller:
     type: "pass_through_controllers/CartesianTrajectoryController"
     joints: *robot_joints
 
+twist_controller:
+  type: "ros_controllers_cartesian/TwistController"
+  frame_id: "tool0_controller"
+  publish_rate: *loop_hz
+  joints: *robot_joints
+
+pose_based_cartesian_traj_controller:
+    type: pose_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0_controller
+    joints: *robot_joints
+
+joint_based_cartesian_traj_controller:
+    type: position_controllers/CartesianTrajectoryController
+
+    # UR driver convention
+    base: base
+    tip: tool0
+    joints: *robot_joints
+
 robot_status_controller:
    type: industrial_robot_status_controller/IndustrialRobotStatusController
    handle_name: industrial_robot_status_handle

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -245,8 +245,10 @@ protected:
   hardware_interface::ForceTorqueSensorInterface fts_interface_;
   hardware_interface::JointTrajectoryInterface jnt_traj_interface_;
   hardware_interface::CartesianTrajectoryInterface cart_traj_interface_;
+
   ros_controllers_cartesian::CartesianStateInterface cart_interface_;
   ros_controllers_cartesian::TwistCommandInterface twist_interface_;
+  ros_controllers_cartesian::PoseCommandInterface pose_interface_;
 
   geometry_msgs::Pose cart_pose_;
   geometry_msgs::Twist cart_twist_;
@@ -322,6 +324,7 @@ protected:
   bool joint_forward_controller_running_;
   bool cartesian_forward_controller_running_;
   bool twist_controller_running_;
+  bool pose_controller_running_;
 
   PausingState pausing_state_;
   double pausing_ramp_up_increment_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -52,6 +52,9 @@
 #include <ur_msgs/SetIO.h>
 #include <ur_msgs/SetSpeedSliderFraction.h>
 
+#include <cartesian_interface/cartesian_command_interface.h>
+#include <cartesian_interface/cartesian_state_handle.h>
+
 #include <speed_scaling_interface/speed_scaling_interface.h>
 #include <scaled_joint_trajectory_controller/scaled_joint_command_interface.h>
 
@@ -242,6 +245,8 @@ protected:
   hardware_interface::ForceTorqueSensorInterface fts_interface_;
   hardware_interface::JointTrajectoryInterface jnt_traj_interface_;
   hardware_interface::CartesianTrajectoryInterface cart_traj_interface_;
+  ros_controllers_cartesian::CartesianStateInterface cart_interface_;
+  ros_controllers_cartesian::TwistCommandInterface twist_interface_;
 
   geometry_msgs::Pose cart_pose_;
   geometry_msgs::Twist cart_twist_;
@@ -316,6 +321,7 @@ protected:
   bool velocity_controller_running_;
   bool joint_forward_controller_running_;
   bool cartesian_forward_controller_running_;
+  bool twist_controller_running_;
 
   PausingState pausing_state_;
   double pausing_ramp_up_increment_;

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -41,10 +41,12 @@
   <depend>tf2_msgs</depend>
   <depend>tf</depend>
   <depend>trajectory_msgs</depend>
+  <depend>twist_controller</depend>
   <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
   <depend>ur_msgs</depend>
 
+  <exec_depend>cartesian_trajectory_controller</exec_depend>
   <exec_depend>controller_stopper</exec_depend>
   <exec_depend>force_torque_sensor_controller</exec_depend>
   <exec_depend>industrial_robot_status_controller</exec_depend>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -41,7 +41,6 @@
   <depend>tf2_msgs</depend>
   <depend>tf</depend>
   <depend>trajectory_msgs</depend>
-  <depend>twist_controller</depend>
   <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
   <depend>ur_msgs</depend>
@@ -54,6 +53,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>socat</exec_depend>
+  <exec_depend>twist_controller</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -799,7 +799,6 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
         }
         if (resource_it.hardware_interface == "ros_controllers_cartesian::PoseCommandInterface")
         {
-          ROS_INFO_STREAM("Stopping pose controller");
           pose_controller_running_ = false;
         }
       }
@@ -846,7 +845,6 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
         }
         if (resource_it.hardware_interface == "ros_controllers_cartesian::PoseCommandInterface")
         {
-          ROS_INFO_STREAM("Starting pose controller");
           pose_controller_running_ = true;
         }
       }

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -58,6 +58,7 @@ static const std::bitset<11>
 HardwareInterface::HardwareInterface()
   : joint_position_command_({ 0, 0, 0, 0, 0, 0 })
   , joint_velocity_command_({ 0, 0, 0, 0, 0, 0 })
+  , cartesian_velocity_command_({ 0, 0, 0, 0, 0, 0 })
   , joint_positions_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_velocities_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_efforts_{ { 0, 0, 0, 0, 0, 0 } }
@@ -70,6 +71,7 @@ HardwareInterface::HardwareInterface()
   , velocity_controller_running_(false)
   , joint_forward_controller_running_(false)
   , cartesian_forward_controller_running_(false)
+  , twist_controller_running_(false)
   , pausing_state_(PausingState::RUNNING)
   , pausing_ramp_up_increment_(0.01)
   , controllers_initialized_(false)
@@ -360,6 +362,12 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
       std::bind(&HardwareInterface::startCartesianInterpolation, this, std::placeholders::_1));
   cart_traj_interface_.registerCancelCallback(std::bind(&HardwareInterface::cancelInterpolation, this));
 
+  ros_controllers_cartesian::CartesianStateHandle handle(tf_prefix_ + "base", tf_prefix_ + "tool0_controller",
+                                                         &cart_pose_, &cart_twist_, &cart_accel_, &cart_jerk_);
+  cart_interface_.registerHandle(handle);
+  twist_interface_.registerHandle(ros_controllers_cartesian::TwistCommandHandle(
+      cart_interface_.getHandle(tf_prefix_ + "tool0_controller"), &twist_command_));
+  twist_interface_.getHandle(tf_prefix_ + "tool0_controller");
   // Register interfaces
   registerInterface(&js_interface_);
   registerInterface(&spj_interface_);
@@ -371,6 +379,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   registerInterface(&robot_status_interface_);
   registerInterface(&jnt_traj_interface_);
   registerInterface(&cart_traj_interface_);
+  registerInterface(&twist_interface_);
 
   tcp_pose_pub_.reset(new realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>(root_nh, "/tf", 100));
   io_pub_.reset(new realtime_tools::RealtimePublisher<ur_msgs::IOStates>(robot_hw_nh, "io_states", 1));
@@ -678,6 +687,16 @@ void HardwareInterface::write(const ros::Time& time, const ros::Duration& period
     {
       ur_driver_->writeTrajectoryControlMessage(urcl::control::TrajectoryControlMessage::TRAJECTORY_NOOP);
     }
+    else if (twist_controller_running_)
+    {
+      cartesian_velocity_command_[0] = twist_command_.linear.x;
+      cartesian_velocity_command_[1] = twist_command_.linear.y;
+      cartesian_velocity_command_[2] = twist_command_.linear.z;
+      cartesian_velocity_command_[3] = twist_command_.angular.x;
+      cartesian_velocity_command_[4] = twist_command_.angular.y;
+      cartesian_velocity_command_[5] = twist_command_.angular.z;
+      ur_driver_->writeJointCommand(cartesian_velocity_command_, urcl::comm::ControlMode::MODE_SPEEDL);
+    }
     else
     {
       ur_driver_->writeKeepalive();
@@ -746,6 +765,10 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
         {
           cartesian_forward_controller_running_ = false;
         }
+        if (resource_it.hardware_interface == "cartesian_ros_control::TwistCommandInterface")
+        {
+          twist_controller_running_ = false;
+        }
       }
     }
   }
@@ -783,6 +806,10 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
                                               "allocator<void> > >")
         {
           cartesian_forward_controller_running_ = true;
+        }
+        if (resource_it.hardware_interface == "cartesian_ros_control::TwistCommandInterface")
+        {
+          twist_controller_running_ = true;
         }
       }
     }
@@ -1134,6 +1161,13 @@ bool HardwareInterface::checkControllerClaims(const std::set<std::string>& claim
       {
         return true;
       }
+    }
+  }
+  for (const std::string& jt : claimed_resources)
+  {
+    if ("tool0_controller" == jt)
+    {
+      return true;
     }
   }
   return false;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -786,11 +786,11 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
         {
           cartesian_forward_controller_running_ = false;
         }
-        if (resource_it.hardware_interface == "cartesian_ros_control::TwistCommandInterface")
+        if (resource_it.hardware_interface == "ros_controllers_cartesian::TwistCommandInterface")
         {
           twist_controller_running_ = false;
         }
-        if (resource_it.hardware_interface == "cartesian_ros_control::PoseCommandInterface")
+        if (resource_it.hardware_interface == "ros_controllers_cartesian::PoseCommandInterface")
         {
           ROS_INFO_STREAM("Stopping pose controller");
           pose_controller_running_ = false;
@@ -833,11 +833,11 @@ void HardwareInterface::doSwitch(const std::list<hardware_interface::ControllerI
         {
           cartesian_forward_controller_running_ = true;
         }
-        if (resource_it.hardware_interface == "cartesian_ros_control::TwistCommandInterface")
+        if (resource_it.hardware_interface == "ros_controllers_cartesian::TwistCommandInterface")
         {
           twist_controller_running_ = true;
         }
-        if (resource_it.hardware_interface == "cartesian_ros_control::PoseCommandInterface")
+        if (resource_it.hardware_interface == "ros_controllers_cartesian::PoseCommandInterface")
         {
           ROS_INFO_STREAM("Starting pose controller");
           pose_controller_running_ = true;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -551,6 +551,13 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     cart_twist_.angular.y = tcp_speed_[4];
     cart_twist_.angular.z = tcp_speed_[5];
 
+    KDL::Vector vec = KDL::Vector(tcp_pose_[3], tcp_pose_[4], tcp_pose_[5]);
+
+    double angle = vec.Normalize();
+
+    KDL::Rotation rot = KDL::Rotation::Rot(vec, angle);
+    rot.GetQuaternion(cart_pose_.orientation.x, cart_pose_.orientation.y, cart_pose_.orientation.z,
+                      cart_pose_.orientation.w);
     extractRobotStatus();
 
     publishIOData();

--- a/ur_robot_driver/test/driver.test
+++ b/ur_robot_driver/test/driver.test
@@ -9,13 +9,14 @@
   <include file="$(find ur_robot_driver)/launch/$(arg robot_type)_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
     <arg name="headless_mode" value="true"/>
-    <arg name="stopped_controllers" value="forward_joint_traj_controller forward_cartesian_traj_controller"/>
+    <arg name="stopped_controllers" value="forward_joint_traj_controller forward_cartesian_traj_controller twist_controller pose_based_cartesian_traj_controller joint_based_cartesian_traj_controller"/>
   </include>
 
   <!--If the default controller changes, this remap has to be adapted, as well-->
   <remap from="follow_joint_trajectory" to="/scaled_pos_joint_traj_controller/follow_joint_trajectory" />
   <remap from="forward_cartesian_trajectory" to="/forward_cartesian_traj_controller/follow_cartesian_trajectory" />
   <remap from="forward_joint_trajectory" to="/forward_joint_traj_controller/follow_joint_trajectory" />
+  <remap from="follow_cartesian_trajectory" to="/pose_based_cartesian_traj_controller/follow_cartesian_trajectory" />
 
   <test test-name="integration test" pkg="ur_robot_driver" type="integration_test.py" name="integration_test" time-limit="300.0"/>
 

--- a/ur_robot_driver/test/integration_test.py
+++ b/ur_robot_driver/test/integration_test.py
@@ -57,45 +57,35 @@ class IntegrationTest(unittest.TestCase):
 
         self.set_mode_client = actionlib.SimpleActionClient(
             '/ur_hardware_interface/set_mode', SetModeAction)
-        try:
-            self.set_mode_client.wait_for_server(timeout)
-        except rospy.exceptions.ROSException as err:
+        if not self.set_mode_client.wait_for_server(timeout):
             self.fail(
                 "Could not reach set_mode action. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
         self.trajectory_client = actionlib.SimpleActionClient(
             'follow_joint_trajectory', FollowJointTrajectoryAction)
-        try:
-            self.trajectory_client.wait_for_server(timeout)
-        except rospy.exceptions.ROSException as err:
+        if not self.trajectory_client.wait_for_server(timeout):
             self.fail(
                 "Could not reach controller action. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
         self.cartesian_passthrough_trajectory_client = actionlib.SimpleActionClient(
             'forward_cartesian_trajectory', FollowCartesianTrajectoryAction)
-        try:
-            self.cartesian_passthrough_trajectory_client.wait_for_server(timeout)
-        except rospy.exceptions.ROSException as err:
+        if not self.cartesian_passthrough_trajectory_client.wait_for_server(timeout):
             self.fail(
                 "Could not reach cartesian passthrough controller action. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
         self.joint_passthrough_trajectory_client = actionlib.SimpleActionClient(
             'forward_joint_trajectory', FollowJointTrajectoryAction)
-        try:
-            self.joint_passthrough_trajectory_client.wait_for_server(timeout)
-        except rospy.exceptions.ROSException as err:
+        if not self.joint_passthrough_trajectory_client.wait_for_server(timeout):
             self.fail(
                 "Could not reach joint passthrough controller action. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
         self.cartesian_trajectory_client = actionlib.SimpleActionClient(
             'follow_cartesian_trajectory', FollowCartesianTrajectoryAction)
-        try:
-            self.cartesian_trajectory_client.wait_for_server(timeout)
-        except rospy.exceptions.ROSException as err:
+        if not self.cartesian_trajectory_client.wait_for_server(timeout):
             self.fail(
                 "Could not reach cartesian controller action. Make sure that the driver is actually running."
                 " Msg: {}".format(err))


### PR DESCRIPTION
This PR adds Cartesian streaming control and controllers to the driver.

In analogy to the JointPosition and JointVelocity interface, a Pose and Twist interface is added. We have three controllers added as  examples:
 - `twist_controller`: publish a cartesian twist to the robot's tcp
 - `pose_based_cartesian_traj_controller`: Cartesian trajectory execution using a pose interface
 - `joint_based_cartesian_traj_controller`: Cartesian trajectory execution using an IK and a joint position interface