### PR TITLE
Fix trajectory port

### DIFF
--- a/ur_robot_driver/launch/ur10_bringup.launch
+++ b/ur_robot_driver/launch/ur10_bringup.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur10_bringup.launch
+++ b/ur_robot_driver/launch/ur10_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur10e_bringup.launch
+++ b/ur_robot_driver/launch/ur10e_bringup.launch
@@ -6,6 +6,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur10e_bringup.launch
+++ b/ur_robot_driver/launch/ur10e_bringup.launch
@@ -3,6 +3,7 @@
 
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur16e_bringup.launch
+++ b/ur_robot_driver/launch/ur16e_bringup.launch
@@ -6,6 +6,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur16e_bringup.launch
+++ b/ur_robot_driver/launch/ur16e_bringup.launch
@@ -3,6 +3,7 @@
 
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur3_bringup.launch
+++ b/ur_robot_driver/launch/ur3_bringup.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur3_bringup.launch
+++ b/ur_robot_driver/launch/ur3_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur3e_bringup.launch
+++ b/ur_robot_driver/launch/ur3e_bringup.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur3e_bringup.launch
+++ b/ur_robot_driver/launch/ur3e_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur5_bringup.launch
+++ b/ur_robot_driver/launch/ur5_bringup.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur5_bringup.launch
+++ b/ur_robot_driver/launch/ur5_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur5e_bringup.launch
+++ b/ur_robot_driver/launch/ur5e_bringup.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur5e_bringup.launch
+++ b/ur_robot_driver/launch/ur5e_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller" doc="Controllers that are activated by default."/>
   <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>

--- a/ur_robot_driver/launch/ur_common.launch
+++ b/ur_robot_driver/launch/ur_common.launch
@@ -7,6 +7,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller speed_scaling_state_controller force_torque_sensor_controller robot_status_controller" doc="Controllers that are activated by default."/>
@@ -38,6 +39,7 @@
     <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="script_sender_port" value="$(arg script_sender_port)"/>
+    <arg name="trajectory_interface_port" value="$(arg trajectory_interface_port)"/>
     <arg name="kinematics_config" value="$(arg kinematics_config)"/>
     <arg name="tf_prefix" value="$(arg tf_prefix)"/>
     <arg name="controllers" value="$(arg controllers)"/>

--- a/ur_robot_driver/launch/ur_common.launch
+++ b/ur_robot_driver/launch/ur_common.launch
@@ -4,6 +4,7 @@
   <arg name="use_tool_communication" doc="On e-Series robots tool communication can be enabled with this argument"/>
   <arg name="controller_config_file" doc="Config file used for defining the ROS-Control controllers."/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description."/>
@@ -34,6 +35,7 @@
     <arg name="use_tool_communication" value="$(arg use_tool_communication)"/>
     <arg name="controller_config_file" value="$(arg controller_config_file)"/>
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="script_sender_port" value="$(arg script_sender_port)"/>
     <arg name="kinematics_config" value="$(arg kinematics_config)"/>

--- a/ur_robot_driver/launch/ur_control.launch
+++ b/ur_robot_driver/launch/ur_control.launch
@@ -12,6 +12,7 @@
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
+  <arg name="trajectory_interface_port" default="50003" doc="The driver will offer an interface to receive complete trajectories on this port. To use this, make sure a pass_through_controller is running. See the controller documentation for details."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description. Pass the same config file that is passed to the robot_description."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>
   <arg name="controllers" default="joint_state_controller vel_based_pos_joint_traj_controller force_torque_sensor_controller robot_status_controller"/>
@@ -37,6 +38,7 @@
     <param name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)"/>
     <param name="script_sender_port" type="int" value="$(arg script_sender_port)"/>
+    <param name="trajectory_interface_port" type="int" value="$(arg trajectory_interface_port)"/>
     <rosparam command="load" file="$(arg kinematics_config)" />
     <param name="script_file" value="$(arg urscript_file)"/>
     <param name="output_recipe_file" value="$(arg rtde_output_recipe_file)"/>

--- a/ur_robot_driver/launch/ur_control.launch
+++ b/ur_robot_driver/launch/ur_control.launch
@@ -9,6 +9,7 @@
   <arg name="use_tool_communication" doc="On e-Series robots tool communication can be enabled with this argument"/>
   <arg name="controller_config_file" doc="Config file used for defining the ROS-Control controllers."/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
+  <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description. Pass the same config file that is passed to the robot_description."/>
@@ -33,6 +34,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_robot_driver" type="ur_robot_driver_node" output="screen" launch-prefix="$(arg launch_prefix)" required="true">
     <param name="robot_ip" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)"/>
     <param name="script_sender_port" type="int" value="$(arg script_sender_port)"/>
     <rosparam command="load" file="$(arg kinematics_config)" />
@@ -56,6 +58,7 @@
   <!-- Starts socat to bridge the robot's tool communication interface to a local tty device -->
   <node if="$(arg use_tool_communication)" name="ur_tool_communication_bridge" pkg="ur_robot_driver" type="tool_communication" respawn="false" output="screen">
     <param name="robot_ip" value="$(arg robot_ip)"/>
+    <param name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)"/>
     <param name="script_sender_port" type="int" value="$(arg script_sender_port)"/>
     <param name="device_name" value="$(arg tool_device_name)"/>

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -92,6 +92,10 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
 
   // The driver will offer an interface to receive the program's URScript on this port.
   int script_sender_port = robot_hw_nh.param("script_sender_port", 50002);
+  //
+  // The driver will offer an interface to receive complete trajectories for executing on the robot
+  // controller. This will require running the passthrough_controllers to work.
+  int trajectory_port = robot_hw_nh.param("trajectory_interface_port", 50003);
 
   // When the robot's URDF is being loaded with a prefix, we need to know it here, as well, in order
   // to publish correct frame names for frames reported by the robot directly.
@@ -265,7 +269,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
         robot_ip_, script_filename, output_recipe_filename, input_recipe_filename,
         std::bind(&HardwareInterface::handleRobotProgramState, this, std::placeholders::_1), headless_mode,
         std::move(tool_comm_setup), calibration_checksum, (uint32_t)reverse_port, (uint32_t)script_sender_port,
-        servoj_gain, servoj_lookahead_time, non_blocking_read_, reverse_ip));
+        servoj_gain, servoj_lookahead_time, non_blocking_read_, reverse_ip, trajectory_port));
   }
   catch (urcl::ToolCommNotAvailable& e)
   {

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -84,6 +84,9 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
     return false;
   }
 
+  // IP that will be used for the robot controller to communicate back to the driver.
+  std::string reverse_ip = robot_hw_nh.param<std::string>("reverse_ip", "");
+
   // Port that will be opened to communicate between the driver and the robot controller.
   int reverse_port = robot_hw_nh.param("reverse_port", 50001);
 
@@ -258,11 +261,11 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   ROS_INFO_STREAM("Initializing urdriver");
   try
   {
-    ur_driver_.reset(
-        new urcl::UrDriver(robot_ip_, script_filename, output_recipe_filename, input_recipe_filename,
-                           std::bind(&HardwareInterface::handleRobotProgramState, this, std::placeholders::_1),
-                           headless_mode, std::move(tool_comm_setup), calibration_checksum, (uint32_t)reverse_port,
-                           (uint32_t)script_sender_port, servoj_gain, servoj_lookahead_time, non_blocking_read_));
+    ur_driver_.reset(new urcl::UrDriver(
+        robot_ip_, script_filename, output_recipe_filename, input_recipe_filename,
+        std::bind(&HardwareInterface::handleRobotProgramState, this, std::placeholders::_1), headless_mode,
+        std::move(tool_comm_setup), calibration_checksum, (uint32_t)reverse_port, (uint32_t)script_sender_port,
+        servoj_gain, servoj_lookahead_time, non_blocking_read_, reverse_ip));
   }
   catch (urcl::ToolCommNotAvailable& e)
   {


### PR DESCRIPTION
As the library supports configuring a trajectory port now, we should forward this in the ROS driver, as well. Otherwise, if the default value is always, used, there cannot be multiple instances of the driver running at the same time.

See #429 for example.

This won't be merged, before the library version 0.3.1 is synced to ROS melodic. This should happen rather soon, as the last sync was on June 4th.

Closes #429