### PR TITLE
Publish joint temperature

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -259,7 +259,8 @@ protected:
   std::bitset<11> safety_status_bits_;
 
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>> tcp_pose_pub_;
-  std::unique_ptr<realtime_tools::RealtimePublisher<sensor_msgs::Temperature>> joint_temperatures_pub_;
+  typedef std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::Temperature>> JTPublisherPtr;
+  std::vector<JTPublisherPtr> joint_temperature_pubs_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::IOStates>> io_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::ToolDataMsg>> tool_data_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::RobotMode>> robot_mode_pub_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -44,6 +44,7 @@
 #include <ur_msgs/ToolDataMsg.h>
 #include <ur_msgs/SetIO.h>
 #include <ur_msgs/SetSpeedSliderFraction.h>
+#include <sensor_msgs/Temperature.h>
 
 #include <ur_controllers/speed_scaling_interface.h>
 #include <ur_controllers/scaled_joint_command_interface.h>
@@ -177,6 +178,7 @@ protected:
    */
   void publishPose();
 
+  void publishJointTemperatures(const ros::Time& timestamp);
   void publishIOData();
   void publishToolData();
   void publishRobotAndSafetyMode();
@@ -230,6 +232,7 @@ protected:
   urcl::vector6d_t joint_positions_;
   urcl::vector6d_t joint_velocities_;
   urcl::vector6d_t joint_efforts_;
+  urcl::vector6d_t joint_temperatures_;
   urcl::vector6d_t fts_measurements_;
   urcl::vector6d_t tcp_pose_;
   std::bitset<18> actual_dig_out_bits_;
@@ -256,6 +259,7 @@ protected:
   std::bitset<11> safety_status_bits_;
 
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>> tcp_pose_pub_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<sensor_msgs::Temperature>> joint_temperatures_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::IOStates>> io_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::ToolDataMsg>> tool_data_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::RobotMode>> robot_mode_pub_;

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -1,6 +1,7 @@
 timestamp
 actual_q
 actual_qd
+joint_temperatures
 speed_scaling
 target_speed_fraction
 runtime_state

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -357,7 +357,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   }
   for (size_t i = 0; i < joint_names_.size(); i++)
   {
-    JTPublisherPtr joint_temperature_pub(new realtime_tools::RealtimePublisher<sensor_msgs::Temperature>(robot_hw_nh, "joint_temperatures", 1));
+    JTPublisherPtr joint_temperature_pub(new realtime_tools::RealtimePublisher<sensor_msgs::Temperature>(root_nh, "joint_temperatures/"+joint_names_[i], 1));
     joint_temperature_pubs_.push_back(joint_temperature_pub);
   }
 


### PR DESCRIPTION
Since we need temperature information on the motor level for parameters identification, I implemented publishers for publishing the joint temperature as retrieved by the driver. I am making a pull request in case this would be useful for others too, and to get some feedback on my implementation.

Based on previous discussions at #35 and ros-industrial/ur_modern_driver#81, I used the `sensor_msgs::Temperature` message type and constructed a publisher for each joint. I have two questions:

* Would it make sense to create a custom message for publishing an array of temperatures, so that only one topic would be enough?
* I read at ros-industrial/ur_modern_driver#315 and ros-industrial/ur_modern_driver#320 that link names might be preferred over joint names for the `frame_id`. Is this indeed the case? What would be the most convenient way to retrieve link names?