### PR TITLE
Use thread sanitizer (tsan) to check data races

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -74,6 +74,10 @@ endif()
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
+add_compile_options(-fsanitize=thread)
+add_compile_options(-fno-omit-frame-pointer)
+add_compile_options(-O2)
+add_compile_options(-g)
 
 
 include_directories(
@@ -86,34 +90,34 @@ add_library(ur_robot_driver_plugin
   src/dashboard_client_ros.cpp
   src/hardware_interface.cpp
 )
-target_link_libraries(ur_robot_driver_plugin ur_client_library::urcl ${catkin_LIBRARIES})
+target_link_libraries(ur_robot_driver_plugin ur_client_library::urcl ${catkin_LIBRARIES} tsan)
 add_dependencies(ur_robot_driver_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_library(urcl_log_handler
   src/urcl_log_handler.cpp
 )
-target_link_libraries(urcl_log_handler ${catkin_LIBRARIES} ur_client_library::urcl)
+target_link_libraries(urcl_log_handler ${catkin_LIBRARIES} ur_client_library::urcl tsan)
 
 add_executable(ur_robot_driver_node
   src/dashboard_client_ros.cpp
   src/hardware_interface.cpp
   src/hardware_interface_node.cpp
 )
-target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_client_library::urcl urcl_log_handler)
+target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_client_library::urcl urcl_log_handler tsan)
 add_dependencies(ur_robot_driver_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(dashboard_client
   src/dashboard_client_ros.cpp
   src/dashboard_client_node.cpp
 )
-target_link_libraries(dashboard_client ${catkin_LIBRARIES} ur_client_library::urcl urcl_log_handler)
+target_link_libraries(dashboard_client ${catkin_LIBRARIES} ur_client_library::urcl urcl_log_handler tsan)
 add_dependencies(dashboard_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(robot_state_helper
   src/robot_state_helper.cpp
   src/robot_state_helper_node.cpp
 )
-target_link_libraries(robot_state_helper ${catkin_LIBRARIES} ur_client_library::urcl)
+target_link_libraries(robot_state_helper ${catkin_LIBRARIES} ur_client_library::urcl tsan)
 add_dependencies(robot_state_helper ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
**Background**

Recently, there was [a discussions](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/447) about possible data races in the driver's hardware_interface (PR [here](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/448) by @AndyZe).
While critical parts have been spotted, it might be reasonable to run an in-depth investigation.

**Approach**
In recent versions, GCC has support for [thread sanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual), which seems quite capable of spotting many potential (and actual) race conditions at runtime. Clang has this feature too, but seems to be more difficult to compile-in with a ROS stack.

This PR is not actually going to be merged. Instead, it wanted to start this discussion here. Also because, I didn't manage (yet) to get meaningful output at runtime.

**Compilation**
The ur_robot_drivers CMakeLists.txt gets some additional build flags and we link dynamically against tsan. This step already works.

**Runtime analysis**
Unfortunately, I get segmentation faults relatively early on.

```bash
#0  0x00007ffff71bc3a6 in __sanitizer::SizeClassAllocator64LocalCache<__sanitizer::SizeClassAllocator64<__tsan::AP64> >::Allocate (class_id=2, allocator=0x7ffff7259f40 <__tsan::allocator_placeholder>, this=0x8)
    at ../../../../src/libsanitizer/sanitizer_common/sanitizer_allocator_local_cache.h:33
#1  __sanitizer::CombinedAllocator<__sanitizer::SizeClassAllocator64<__tsan::AP64>, __sanitizer::LargeMmapAllocatorPtrArrayDynamic>::Allocate (this=this@entry=0x7ffff7259f40 <__tsan::allocator_placeholder>, cache=0x8, size=<optimized out>,
    alignment=16) at ../../../../src/libsanitizer/sanitizer_common/sanitizer_allocator_combined.h:69
#2  0x00007ffff71ba33a in __tsan::user_alloc_internal (thr=thr@entry=0x7ffff12beb80, pc=pc@entry=140737339191347,
    sz=sz@entry=24, align=align@entry=16, signal=signal@entry=true) at ../../../../src/libsanitizer/tsan/tsan_rtl.h:431
#3  0x00007ffff71ba468 in __tsan::user_alloc (thr=thr@entry=0x7ffff12beb80, pc=pc@entry=140737339191347, sz=sz@entry=24)
    at ../../../../src/libsanitizer/tsan/tsan_mman.cpp:197
#4  0x00007ffff71bf044 in operator new (size=24) at ../../../../src/libsanitizer/tsan/tsan_new_delete.cpp:64
#5  0x00007ffff7ed4611 in std::vector<pollfd, std::allocator<pollfd> >::_M_default_append(unsigned long) ()
   from /opt/ros/noetic/lib/libroscpp.so
#6  0x00007ffff7ed31e8 in ros::PollSet::createNativePollset() () from /opt/ros/noetic/lib/libroscpp.so
#7  0x00007ffff7ed32a1 in ros::PollSet::update(int) () from /opt/ros/noetic/lib/libroscpp.so
#8  0x00007ffff7e6529d in ros::PollManager::threadFunc() () from /opt/ros/noetic/lib/libroscpp.so
#9  0x00007ffff694143b in ?? () from /lib/x86_64-linux-gnu/libboost_thread.so.1.71.0
#10 0x00007ffff7d18609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#11 0x00007ffff6cbc293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

```

Any help is highly welcome!

