### PR TITLE
Fix compile erros when using RoboStack (conda)

### DIFF
--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(ur_client_library REQUIRED)
+find_package(console_bridge REQUIRED)
 
 # create alias for the '_INCLUDE_DIR' variable, to help Catkin export it
 set(YAML_CPP_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
@@ -50,6 +51,7 @@ target_link_libraries(calibration_correction
   ${catkin_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   ur_client_library::urcl
+  console_bridge::console_bridge
 )
 
 install(DIRECTORY launch

--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -4,6 +4,8 @@ project(ur_calibration)
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
+add_definitions(-D__STDC_FORMAT_MACROS)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   ur_robot_driver

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(catkin REQUIRED
 )
 find_package(Boost REQUIRED)
 find_package(ur_client_library REQUIRED)
+find_package(console_bridge REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
@@ -92,7 +93,7 @@ add_dependencies(ur_robot_driver_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${ca
 add_library(urcl_log_handler
   src/urcl_log_handler.cpp
 )
-target_link_libraries(urcl_log_handler ${catkin_LIBRARIES} ur_client_library::urcl)
+target_link_libraries(urcl_log_handler ${catkin_LIBRARIES} ur_client_library::urcl console_bridge::console_bridge)
 
 add_executable(ur_robot_driver_node
   src/dashboard_client_ros.cpp


### PR DESCRIPTION
The RoboStack maintainers helped to fix compile errors when building the UR drivers using a conda environment. conda is, in my humble opinion, very useful and the suggested changes might be helpful for others.

For more information, please see RoboStack/ros-noetic#155 and RoboStack/ros-noetic#157 .