### PR TITLE
Wait for controller action server in test_move.

### DIFF
--- a/ur_robot_driver/scripts/test_move
+++ b/ur_robot_driver/scripts/test_move
@@ -107,6 +107,12 @@ class TrajectoryClient:
             FollowJointTrajectoryAction,
         )
 
+        # Wait for action server to be ready
+        timeout = rospy.Duration(5)
+        if not trajectory_client.wait_for_server(timeout):
+            rospy.logerr("Could not reach controller action server.")
+            sys.exit(-1)
+
         # Create and fill trajectory goal
         goal = FollowJointTrajectoryGoal()
         goal.trajectory.joint_names = JOINT_NAMES
@@ -142,6 +148,12 @@ class TrajectoryClient:
             "{}/follow_cartesian_trajectory".format(self.cartesian_trajectory_controller),
             FollowCartesianTrajectoryAction,
         )
+
+        # Wait for action server to be ready
+        timeout = rospy.Duration(5)
+        if not trajectory_client.wait_for_server(timeout):
+            rospy.logerr("Could not reach controller action server.")
+            sys.exit(-1)
 
         # The following list are arbitrary positions
         # Change to your own needs if desired


### PR DESCRIPTION
Without waiting for the server to be ready, it is possible that the call to `trajectory_client.send_goal` happens before the server is ready to accept it. In my experience this doesn't happen in `test_move` script because the call to `self.ask_confirmation` takes enough time for the server to be ready. However, when I went to write my own motion script based on this one without the `self.ask_confirmation`, the server was not ready in time. It took sometime for me to debug, so seems like it may be useful to include for others.