### PR TITLE
Add optional topic rename for speed scaling factor

### DIFF
--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -65,6 +65,10 @@ tf_prefix used for the robot.
 
 Parameter to set the id of the wrench frame, required if using multiple robots
 
+##### speed_scaling_id (default: "speed_scaling_factor")
+
+Set the topic on which this robot publishes its speed scaling factor.
+
 ##### tool_baud_rate (default: "115200")
 
 Baud rate used for tool communication. Only used, when `use_tool_communication` is set to true.

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -87,6 +87,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   joint_efforts_ = { { 0, 0, 0, 0, 0, 0 } };
   std::string script_filename;
   std::string wrench_frame_id;
+  std::string speed_scaling_id;
   std::string output_recipe_filename;
   std::string input_recipe_filename;
 
@@ -115,6 +116,9 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
 
   // Optional parameter to change the id of the wrench frame
   robot_hw_nh.param<std::string>("wrench_frame_id", wrench_frame_id, "wrench");
+
+  // Optional parameter to change the id of the speed scaling topic
+  robot_hw_nh.param<std::string>("speed_scaling_id", speed_scaling_id, "speed_scaling_factor");
 
   // Path to the urscript code that will be sent to the robot.
   if (!robot_hw_nh.getParam("script_file", script_filename))
@@ -348,8 +352,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
         js_interface_.getHandle(joint_names_[i]), &joint_velocity_command_[i], &speed_scaling_combined_));
   }
 
-  speedsc_interface_.registerHandle(
-      scaled_controllers::SpeedScalingHandle("speed_scaling_factor", &speed_scaling_combined_));
+  speedsc_interface_.registerHandle(scaled_controllers::SpeedScalingHandle(speed_scaling_id, &speed_scaling_combined_));
 
   fts_interface_.registerHandle(hardware_interface::ForceTorqueSensorHandle(
       wrench_frame_id, tf_prefix_ + "tool0_controller", fts_measurements_.begin(), fts_measurements_.begin() + 3));


### PR DESCRIPTION
## What?
I've added the ability to change the default topic on which the speed scaling factor is published.
## Why?
This homogenizes the behavior, considering the wrench topic can currently be renamed. I've been working on a project that involves two UR arms running simultaneously, and it has been useful to maintain separate speed sliders rather than being forced to receive only one robot's slider state. In particular, if the robot which is not publishing state protective stops, I have difficulty stopping its related hardware because I have no programmatic indication of the fault.
## How?
Use a ROS Param just like the wrench topic is defined.
## Testing?
I have been using this in my project without any visible side effects.