### PR TITLE
Implemented ROS topic to enable the freedrive mode.

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -213,6 +213,7 @@ protected:
   bool resendRobotProgram(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   bool zeroFTSensor(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   void commandCallback(const std_msgs::StringConstPtr& msg);
+  void freedriveCallback(const std_msgs::Float64Ptr& msg);
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
   std::unique_ptr<DashboardClientROS> dashboard_client_;
@@ -315,6 +316,7 @@ protected:
   ros::ServiceServer set_io_srv_;
   ros::ServiceServer resend_robot_program_srv_;
   ros::Subscriber command_sub_;
+  ros::Subscriber freedrive_sub_;
 
   industrial_robot_status_interface::RobotStatus robot_status_resource_{};
   industrial_robot_status_interface::IndustrialRobotStatusInterface robot_status_interface_{};


### PR DESCRIPTION
Implements a basic way to enable freedrive_mode via a ROS topic.

To test: send a message to the "enable_freedrive_mode" topic with a float value specifying seconds to be in freedrive mode.

Using "0.0" will enter freedrive_mode until the robot stops being moved continously (and at least 3 seconds to allow for start of the movement).

This is not a final implementation of this feature.