### PR TITLE
WIP: Use anchors and aliases for each joint in controller config + cleanup

### DIFF
--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -1,142 +1,142 @@
 # Settings for ros_control control loop
 hardware_control_loop:
-   loop_hz: &loop_hz 125
+  loop_hz: &loop_hz 125
 
 # Settings for ros_control hardware interface
 ur_hardware_interface:
-   joints: &robot_joints
-     - shoulder_pan_joint
-     - shoulder_lift_joint
-     - elbow_joint
-     - wrist_1_joint
-     - wrist_2_joint
-     - wrist_3_joint
+  joints: &robot_joints
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
 
 # Publish all joint states ----------------------------------
 joint_state_controller:
-   type:         joint_state_controller/JointStateController
-   publish_rate: *loop_hz
+  type:         joint_state_controller/JointStateController
+  publish_rate: *loop_hz
 
 # Publish wrench ----------------------------------
 force_torque_sensor_controller:
-   type:         force_torque_sensor_controller/ForceTorqueSensorController
-   publish_rate: *loop_hz
+  type:         force_torque_sensor_controller/ForceTorqueSensorController
+  publish_rate: *loop_hz
 
 # Publish speed_scaling factor
 speed_scaling_state_controller:
-   type:         scaled_controllers/SpeedScalingStateController
-   publish_rate: *loop_hz
+  type:         scaled_controllers/SpeedScalingStateController
+  publish_rate: *loop_hz
 
 # Joint Trajectory Controller - position based -------------------------------
 # For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
 scaled_pos_joint_traj_controller:
-   type: position_controllers/ScaledJointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-      elbow_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.2, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
+  type: position_controllers/ScaledJointTrajectoryController
+  joints: *robot_joints
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
+    shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
+    elbow_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_1_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_2_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate: *loop_hz
+  action_monitor_rate: 20
 
 pos_joint_traj_controller:
-   type: position_controllers/JointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-      elbow_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.2, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
+  type: position_controllers/JointTrajectoryController
+  joints: *robot_joints
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
+    shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
+    elbow_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_1_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_2_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate: *loop_hz
+  action_monitor_rate: 20
 
 scaled_vel_joint_traj_controller:
-   type: velocity_controllers/ScaledJointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-      elbow_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-   # Use a feedforward term to reduce the size of PID gains
-   velocity_ff:
-      shoulder_pan_joint: 1.0
-      shoulder_lift_joint: 1.0
-      elbow_joint: 1.0
-      wrist_1_joint: 1.0
-      wrist_2_joint: 1.0
-      wrist_3_joint: 1.0
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
+  type: velocity_controllers/ScaledJointTrajectoryController
+  joints: *robot_joints
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+    shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+    elbow_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+  gains:
+    #!!These values have not been optimized!!
+    shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+  # Use a feedforward term to reduce the size of PID gains
+  velocity_ff:
+    shoulder_pan_joint: 1.0
+    shoulder_lift_joint: 1.0
+    elbow_joint: 1.0
+    wrist_1_joint: 1.0
+    wrist_2_joint: 1.0
+    wrist_3_joint: 1.0
+  stop_trajectory_duration: 0.5
+  state_publish_rate: *loop_hz
+  action_monitor_rate: 20
 
 vel_joint_traj_controller:
-   type: velocity_controllers/JointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-      elbow_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-   # Use a feedforward term to reduce the size of PID gains
-   velocity_ff:
-      shoulder_pan_joint: 1.0
-      shoulder_lift_joint: 1.0
-      elbow_joint: 1.0
-      wrist_1_joint: 1.0
-      wrist_2_joint: 1.0
-      wrist_3_joint: 1.0
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
+  type: velocity_controllers/JointTrajectoryController
+  joints: *robot_joints
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+    shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+    elbow_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+    wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+  gains:
+    #!!These values have not been optimized!!
+    shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+  # Use a feedforward term to reduce the size of PID gains
+  velocity_ff:
+    shoulder_pan_joint: 1.0
+    shoulder_lift_joint: 1.0
+    elbow_joint: 1.0
+    wrist_1_joint: 1.0
+    wrist_2_joint: 1.0
+    wrist_3_joint: 1.0
+  stop_trajectory_duration: 0.5
+  state_publish_rate: *loop_hz
+  action_monitor_rate: 20
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:
-   type: velocity_controllers/JointGroupVelocityController
-   joints: *robot_joints
+  type: velocity_controllers/JointGroupVelocityController
+  joints: *robot_joints
 
 forward_joint_traj_controller:
-    type: "pass_through_controllers/JointTrajectoryController"
-    joints: *robot_joints
+  type: "pass_through_controllers/JointTrajectoryController"
+  joints: *robot_joints
 
 forward_cartesian_traj_controller:
-    type: "pass_through_controllers/CartesianTrajectoryController"
-    joints: *robot_joints
+  type: "pass_through_controllers/CartesianTrajectoryController"
+  joints: *robot_joints
 
 twist_controller:
   type: "ros_controllers_cartesian/TwistController"
@@ -145,22 +145,22 @@ twist_controller:
   joints: *robot_joints
 
 pose_based_cartesian_traj_controller:
-    type: pose_controllers/CartesianTrajectoryController
+  type: pose_controllers/CartesianTrajectoryController
 
-    # UR driver convention
-    base: base
-    tip: tool0_controller
-    joints: *robot_joints
+  # UR driver convention
+  base: base
+  tip: tool0_controller
+  joints: *robot_joints
 
 joint_based_cartesian_traj_controller:
-    type: position_controllers/CartesianTrajectoryController
+  type: position_controllers/CartesianTrajectoryController
 
-    # UR driver convention
-    base: base
-    tip: tool0
-    joints: *robot_joints
+  # UR driver convention
+  base: base
+  tip: tool0
+  joints: *robot_joints
 
 robot_status_controller:
-   type: industrial_robot_status_controller/IndustrialRobotStatusController
-   handle_name: industrial_robot_status_handle
-   publish_rate: 10
+  type: industrial_robot_status_controller/IndustrialRobotStatusController
+  handle_name: industrial_robot_status_handle
+  publish_rate: 10

--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -131,16 +131,16 @@ joint_group_vel_controller:
   joints: *robot_joints
 
 forward_joint_traj_controller:
-  type: "pass_through_controllers/JointTrajectoryController"
+  type: pass_through_controllers/JointTrajectoryController
   joints: *robot_joints
 
 forward_cartesian_traj_controller:
-  type: "pass_through_controllers/CartesianTrajectoryController"
+  type: pass_through_controllers/CartesianTrajectoryController
   joints: *robot_joints
 
 twist_controller:
-  type: "ros_controllers_cartesian/TwistController"
-  frame_id: "tool0_controller"
+  type: ros_controllers_cartesian/TwistController
+  frame_id: tool0_controller
   publish_rate: *loop_hz
   joints: *robot_joints
 

--- a/ur_robot_driver/config/ur3_controllers.yaml
+++ b/ur_robot_driver/config/ur3_controllers.yaml
@@ -5,12 +5,12 @@ hardware_control_loop:
 # Settings for ros_control hardware interface
 ur_hardware_interface:
   joints: &robot_joints
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
+    - &joint1 shoulder_pan_joint
+    - &joint2 shoulder_lift_joint
+    - &joint3 elbow_joint
+    - &joint4 wrist_1_joint
+    - &joint5 wrist_2_joint
+    - &joint6 wrist_3_joint
 
 # Publish all joint states ----------------------------------
 joint_state_controller:
@@ -35,12 +35,12 @@ scaled_pos_joint_traj_controller:
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
-    shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-    shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-    elbow_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+    *joint1: {trajectory: 0.2, goal: 0.1}
+    *joint2: {trajectory: 0.2, goal: 0.1}
+    *joint3: {trajectory: 0.2, goal: 0.1}
+    *joint4: {trajectory: 0.2, goal: 0.1}
+    *joint5: {trajectory: 0.2, goal: 0.1}
+    *joint6: {trajectory: 0.2, goal: 0.1}
   stop_trajectory_duration: 0.5
   state_publish_rate: *loop_hz
   action_monitor_rate: 20
@@ -51,12 +51,12 @@ pos_joint_traj_controller:
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
-    shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-    shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-    elbow_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-    wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+    *joint1: {trajectory: 0.2, goal: 0.1}
+    *joint2: {trajectory: 0.2, goal: 0.1}
+    *joint3: {trajectory: 0.2, goal: 0.1}
+    *joint4: {trajectory: 0.2, goal: 0.1}
+    *joint5: {trajectory: 0.2, goal: 0.1}
+    *joint6: {trajectory: 0.2, goal: 0.1}
   stop_trajectory_duration: 0.5
   state_publish_rate: *loop_hz
   action_monitor_rate: 20
@@ -67,28 +67,28 @@ scaled_vel_joint_traj_controller:
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
-    shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-    shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-    elbow_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+    *joint1: {trajectory: 0.1, goal: 0.1}
+    *joint2: {trajectory: 0.1, goal: 0.1}
+    *joint3: {trajectory: 0.1, goal: 0.1}
+    *joint4: {trajectory: 0.1, goal: 0.1}
+    *joint5: {trajectory: 0.1, goal: 0.1}
+    *joint6: {trajectory: 0.1, goal: 0.1}
   gains:
     #!!These values have not been optimized!!
-    shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    *joint1: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint2: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint3: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint4: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint5: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint6: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
   # Use a feedforward term to reduce the size of PID gains
   velocity_ff:
-    shoulder_pan_joint: 1.0
-    shoulder_lift_joint: 1.0
-    elbow_joint: 1.0
-    wrist_1_joint: 1.0
-    wrist_2_joint: 1.0
-    wrist_3_joint: 1.0
+    *joint1: 1.0
+    *joint2: 1.0
+    *joint3: 1.0
+    *joint4: 1.0
+    *joint5: 1.0
+    *joint6: 1.0
   stop_trajectory_duration: 0.5
   state_publish_rate: *loop_hz
   action_monitor_rate: 20
@@ -99,28 +99,28 @@ vel_joint_traj_controller:
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
-    shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-    shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-    elbow_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-    wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+    *joint1: {trajectory: 0.1, goal: 0.1}
+    *joint2: {trajectory: 0.1, goal: 0.1}
+    *joint3: {trajectory: 0.1, goal: 0.1}
+    *joint4: {trajectory: 0.1, goal: 0.1}
+    *joint5: {trajectory: 0.1, goal: 0.1}
+    *joint6: {trajectory: 0.1, goal: 0.1}
   gains:
     #!!These values have not been optimized!!
-    shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-    wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+    *joint1: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint2: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint3: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint4: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint5: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
+    *joint6: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
   # Use a feedforward term to reduce the size of PID gains
   velocity_ff:
-    shoulder_pan_joint: 1.0
-    shoulder_lift_joint: 1.0
-    elbow_joint: 1.0
-    wrist_1_joint: 1.0
-    wrist_2_joint: 1.0
-    wrist_3_joint: 1.0
+    *joint1: 1.0
+    *joint2: 1.0
+    *joint3: 1.0
+    *joint4: 1.0
+    *joint5: 1.0
+    *joint6: 1.0
   stop_trajectory_duration: 0.5
   state_publish_rate: *loop_hz
   action_monitor_rate: 20


### PR DESCRIPTION
This PR uses anchors and aliases on each robot joint and sets indentation level to 2 spaces (there were mixed indentation). This makes the following benefits:
- Same indentation level (set to 2 but can be anything)
- Consistency with string values (removed dquotes)
- PID and trajectory/goal section is easier on the eyes...
- Adding a `prefix` to joint names is easier (less search and replace)

Only did the changes for the UR3. If you think this change could be merged, I will modify the other UR config files.