### PR TITLE
Change README to use the description from ros-industrial/universal_robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ $ mkdir -p catkin_ws/src && cd catkin_ws
 # clone the driver
 $ git clone https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git src/Universal_Robots_ROS_Driver
 
-# clone fork of the description. This is currently necessary, until the changes are merged upstream.
-$ git clone -b calibration_devel https://github.com/fmauch/universal_robot.git src/fmauch_universal_robot
+# clone the description. Currently, it is necessary to use the [`melodic-devel-staging`](https://github.com/ros-industrial/universal_robot/tree/melodic-devel-staging) branch.
+$ git clone -b melodic-devel-staging https://github.com/ros-industrial/universal_robot.git
 
 # install dependencies
 $ sudo apt update -qq
@@ -155,7 +155,7 @@ $ source /opt/ros/<your_ros_version>/setup.bash
 $ mkdir -p catkin_ws/src && cd catkin_ws
 $ git clone -b boost https://github.com/UniversalRobots/Universal_Robots_Client_Library.git src/Universal_Robots_Client_Library
 $ git clone https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git src/Universal_Robots_ROS_Driver
-$ git clone -b calibration_devel https://github.com/fmauch/universal_robot.git src/fmauch_universal_robot
+$ git clone -b melodic-devel-staging https://github.com/ros-industrial/universal_robot.git src/universal_robot
 $ sudo apt update -qq
 $ rosdep update
 $ rosdep install --from-paths src --ignore-src -y

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ mkdir -p catkin_ws/src && cd catkin_ws
 # clone the driver
 $ git clone https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git src/Universal_Robots_ROS_Driver
 
-# clone the description. Currently, it is necessary to use the [`melodic-devel-staging`](https://github.com/ros-industrial/universal_robot/tree/melodic-devel-staging) branch.
+# clone the description. Currently, it is necessary to use the melodic-devel-staging branch.
 $ git clone -b melodic-devel-staging https://github.com/ros-industrial/universal_robot.git
 
 # install dependencies


### PR DESCRIPTION
Since https://github.com/ros-industrial/universal_robot/pull/538 is merged, we can now direct users to the upstream repo directly.