### PR TITLE
Dashboard service to query whether the robot is in remote control

### DIFF
--- a/ur_dashboard_msgs/CMakeLists.txt
+++ b/ur_dashboard_msgs/CMakeLists.txt
@@ -62,6 +62,7 @@ add_service_files(
   GetProgramState.srv
   GetRobotMode.srv
   GetSafetyMode.srv
+  IsInRemoteControl.srv
   IsProgramRunning.srv
   IsProgramSaved.srv
   Load.srv

--- a/ur_dashboard_msgs/srv/IsInRemoteControl.srv
+++ b/ur_dashboard_msgs/srv/IsInRemoteControl.srv
@@ -1,4 +1,4 @@
 ---
 string answer
-bool in_remote_control # is a program running?
+bool in_remote_control # is the robot currently in remote control mode?
 bool success # Did the dashboard server call succeed?

--- a/ur_dashboard_msgs/srv/IsInRemoteControl.srv
+++ b/ur_dashboard_msgs/srv/IsInRemoteControl.srv
@@ -1,0 +1,4 @@
+---
+string answer
+bool in_remote_control # is a program running?
+bool success # Did the dashboard server call succeed?

--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -736,6 +736,10 @@ Query whether there is currently a program running
 
 Query whether the current program is saved
 
+##### dashboard/in_remote_control ([ur_dashboard_msgs/IsInRemoteControl](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/IsInRemoteControl.html))
+
+Query whether the robot is in remote control
+
 ##### dashboard/program_state ([ur_dashboard_msgs/GetProgramState](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/GetProgramState.html))
 
 Service to query the current program state

--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -736,7 +736,7 @@ Query whether there is currently a program running
 
 Query whether the current program is saved
 
-##### dashboard/in_remote_control ([ur_dashboard_msgs/IsInRemoteControl](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/IsInRemoteControl.html))
+##### dashboard/is_in_remote_control ([ur_dashboard_msgs/IsInRemoteControl](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/IsInRemoteControl.html))
 
 Query whether the robot is currently in remote control mode. This is only available on e-Series models.
 

--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -738,7 +738,7 @@ Query whether the current program is saved
 
 ##### dashboard/in_remote_control ([ur_dashboard_msgs/IsInRemoteControl](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/IsInRemoteControl.html))
 
-Query whether the robot is in remote control
+Query whether the robot is currently in remote control mode. This is only available on e-Series models.
 
 ##### dashboard/program_state ([ur_dashboard_msgs/GetProgramState](http://docs.ros.org/api/ur_dashboard_msgs/html/srv/GetProgramState.html))
 
@@ -783,7 +783,7 @@ Service to set any of the robot's IOs
 ##### set_speed_slider (ur_msgs/SetSpeedSliderFraction)
 
 Set the speed slider fraction used by the robot's execution. Values should be between 0 and 1. Only set this smaller than 1 if you are using the scaled controllers (as by default) or you know what you're doing. Using this with other controllers might lead to unexpected behaviors.
- 
+
 ##### set_payload (ur_msgs/SetPayload)
 
 Setup the mounted payload through a ROS service
@@ -850,26 +850,25 @@ Specify lookahead time for servoing to position in joint space. A longer lookahe
 
 When the robot's URDF is being loaded with a prefix, we need to know it here, as well, in order to publish correct frame names for frames reported by the robot directly.
 
-
 ##### tool_baud_rate (Required)
 
-Baud rate used for tool communication. Will be set as soon as the UR-Program on the robot is started. See UR documentation for valid baud rates.  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
+Baud rate used for tool communication. Will be set as soon as the UR-Program on the robot is started. See UR documentation for valid baud rates. Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
 
 ##### tool_parity (Required)
 
-Parity used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 0 (None), 1 (odd) and 2 (even).  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
+Parity used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 0 (None), 1 (odd) and 2 (even). Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
 
 ##### tool_rx_idle_chars (Required)
 
-Number of idle chars for the RX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=1.0, max=40.0  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
+Number of idle chars for the RX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=1.0, max=40.0 Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
 
 ##### tool_stop_bits (Required)
 
-Number of stop bits used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 1 or 2.  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
+Number of stop bits used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 1 or 2. Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
 
 ##### tool_tx_idle_chars (Required)
 
-Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=0.0, max=40.0  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
+Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=0.0, max=40.0 Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
 
 ##### tool_voltage (Required)
 
@@ -889,11 +888,9 @@ Whenever the runtime state of the "External Control" program node in the UR-prog
 
 ##### script_command ([std_msgs/String](http://docs.ros.org/api/std_msgs/html/msg/String.html))
 
-Send arbitrary script commands to this topic. Note: On e-Series the robot has to be in remote-control mode.  Sending scripts to this will stop program execution unless wrapped in a secondary program:  sec myProgram(): set_digital_out(0, True) end
+Send arbitrary script commands to this topic. Note: On e-Series the robot has to be in remote-control mode. Sending scripts to this will stop program execution unless wrapped in a secondary program: sec myProgram(): set_digital_out(0, True) end
 
 ### dashboard_client
-
-
 
 #### Advertised Services
 
@@ -1009,7 +1006,7 @@ The IP address under which the robot is reachable.
 
 ### robot_state_helper
 
-This node prints the robot- and safety mode to ROS logging and offers an action to set the robot to a specific mode (e.g. for initial startup or recovery after a protective stop or EM-Stop).  It should best be started inside the hardware interface's namespace
+This node prints the robot- and safety mode to ROS logging and offers an action to set the robot to a specific mode (e.g. for initial startup or recovery after a protective stop or EM-Stop). It should best be started inside the hardware interface's namespace
 
 #### Service Clients
 
@@ -1064,4 +1061,3 @@ By default, socat will create a pty in /dev/pts/N with n being an increasing num
 ##### ~robot_ip (Required)
 
 IP address of the robot
-

--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -783,7 +783,7 @@ Service to set any of the robot's IOs
 ##### set_speed_slider (ur_msgs/SetSpeedSliderFraction)
 
 Set the speed slider fraction used by the robot's execution. Values should be between 0 and 1. Only set this smaller than 1 if you are using the scaled controllers (as by default) or you know what you're doing. Using this with other controllers might lead to unexpected behaviors.
-
+ 
 ##### set_payload (ur_msgs/SetPayload)
 
 Setup the mounted payload through a ROS service
@@ -850,25 +850,26 @@ Specify lookahead time for servoing to position in joint space. A longer lookahe
 
 When the robot's URDF is being loaded with a prefix, we need to know it here, as well, in order to publish correct frame names for frames reported by the robot directly.
 
+
 ##### tool_baud_rate (Required)
 
-Baud rate used for tool communication. Will be set as soon as the UR-Program on the robot is started. See UR documentation for valid baud rates. Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
+Baud rate used for tool communication. Will be set as soon as the UR-Program on the robot is started. See UR documentation for valid baud rates.  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
 
 ##### tool_parity (Required)
 
-Parity used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 0 (None), 1 (odd) and 2 (even). Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
+Parity used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 0 (None), 1 (odd) and 2 (even).  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
 
 ##### tool_rx_idle_chars (Required)
 
-Number of idle chars for the RX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=1.0, max=40.0 Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
+Number of idle chars for the RX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=1.0, max=40.0  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
 
 ##### tool_stop_bits (Required)
 
-Number of stop bits used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 1 or 2. Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
+Number of stop bits used for tool communication. Will be set as soon as the UR-Program on the robot is started. Can be 1 or 2.  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
 
 ##### tool_tx_idle_chars (Required)
 
-Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=0.0, max=40.0 Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE. Then, this parameter is required.
+Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the robot is started. Valid values: min=0.0, max=40.0  Note: This parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.  Then, this parameter is required.
 
 ##### tool_voltage (Required)
 
@@ -888,9 +889,11 @@ Whenever the runtime state of the "External Control" program node in the UR-prog
 
 ##### script_command ([std_msgs/String](http://docs.ros.org/api/std_msgs/html/msg/String.html))
 
-Send arbitrary script commands to this topic. Note: On e-Series the robot has to be in remote-control mode. Sending scripts to this will stop program execution unless wrapped in a secondary program: sec myProgram(): set_digital_out(0, True) end
+Send arbitrary script commands to this topic. Note: On e-Series the robot has to be in remote-control mode.  Sending scripts to this will stop program execution unless wrapped in a secondary program:  sec myProgram(): set_digital_out(0, True) end
 
 ### dashboard_client
+
+
 
 #### Advertised Services
 
@@ -1006,7 +1009,7 @@ The IP address under which the robot is reachable.
 
 ### robot_state_helper
 
-This node prints the robot- and safety mode to ROS logging and offers an action to set the robot to a specific mode (e.g. for initial startup or recovery after a protective stop or EM-Stop). It should best be started inside the hardware interface's namespace
+This node prints the robot- and safety mode to ROS logging and offers an action to set the robot to a specific mode (e.g. for initial startup or recovery after a protective stop or EM-Stop).  It should best be started inside the hardware interface's namespace
 
 #### Service Clients
 
@@ -1061,3 +1064,4 @@ By default, socat will create a pty in /dev/pts/N with n being an increasing num
 ##### ~robot_ip (Required)
 
 IP address of the robot
+

--- a/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
+++ b/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
@@ -121,11 +121,11 @@ private:
   ros::ServiceServer running_service_;
   ros::ServiceServer get_loaded_program_service_;
   ros::ServiceServer is_program_saved_service_;
+  ros::ServiceServer is_in_remote_control_service_;
   ros::ServiceServer program_state_service_;
   ros::ServiceServer polyscope_version_service_;
   ros::ServiceServer safety_mode_service_;
   ros::ServiceServer robot_mode_service_;
-  ros::ServiceServer is_in_remote_control_service_;
 
   ros::ServiceServer raw_request_service_;
 

--- a/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
+++ b/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
@@ -47,6 +47,7 @@
 #include <ur_dashboard_msgs/ProgramState.h>
 #include <ur_dashboard_msgs/GetRobotMode.h>
 #include <ur_dashboard_msgs/GetSafetyMode.h>
+#include <ur_dashboard_msgs/IsInRemoteControl.h>
 #include <ur_dashboard_msgs/RawRequest.h>
 
 namespace ur_driver
@@ -89,6 +90,8 @@ private:
                              ur_dashboard_msgs::GetSafetyMode::Response& resp);
   bool handleRobotModeQuery(ur_dashboard_msgs::GetRobotMode::Request& req,
                             ur_dashboard_msgs::GetRobotMode::Response& resp);
+  bool handleRemoteControlQuery(ur_dashboard_msgs::IsInRemoteControl::Request& req,
+                                ur_dashboard_msgs::IsInRemoteControl::Response& resp);
 
   bool connect();
 
@@ -122,6 +125,7 @@ private:
   ros::ServiceServer polyscope_version_service_;
   ros::ServiceServer safety_mode_service_;
   ros::ServiceServer robot_mode_service_;
+  ros::ServiceServer is_in_remote_control_service_;
 
   ros::ServiceServer raw_request_service_;
 

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -120,6 +120,9 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
   // Query whether the current program is saved
   is_program_saved_service_ = nh_.advertiseService("program_saved", &DashboardClientROS::handleSavedQuery, this);
 
+  // Query whether the robot is in remote control
+  is_in_remote_control_service_ = nh_.advertiseService("in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
+
   // Service to show a popup on the UR Teach pendant.
   popup_service_ = nh_.advertiseService<ur_dashboard_msgs::Popup::Request, ur_dashboard_msgs::Popup::Response>(
       "popup", [&](ur_dashboard_msgs::Popup::Request& req, ur_dashboard_msgs::Popup::Response& resp) {
@@ -151,9 +154,6 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
 
   // Service to query the current robot mode
   robot_mode_service_ = nh_.advertiseService("get_robot_mode", &DashboardClientROS::handleRobotModeQuery, this);
-
-  // Service to query whether the robot is in remote control
-  is_in_remote_control_service_ = nh_.advertiseService("is_in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
 
   // Service to add a message to the robot's log
   add_to_log_service_ =

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -152,6 +152,9 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
   // Service to query the current robot mode
   robot_mode_service_ = nh_.advertiseService("get_robot_mode", &DashboardClientROS::handleRobotModeQuery, this);
 
+  // Service to query whether the robot is in remote control
+  is_in_remote_control_service_ = nh_.advertiseService("is_in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
+
   // Service to add a message to the robot's log
   add_to_log_service_ =
       nh_.advertiseService<ur_dashboard_msgs::AddToLog::Request, ur_dashboard_msgs::AddToLog::Response>(
@@ -216,6 +219,22 @@ bool DashboardClientROS::handleSavedQuery(ur_dashboard_msgs::IsProgramSaved::Req
   {
     resp.program_saved = (match[1] == "true");
     resp.program_name = match[2];
+  }
+
+  return true;
+}
+
+bool DashboardClientROS::handleRemoteControlQuery(ur_dashboard_msgs::IsInRemoteControl::Request& req,
+                                                  ur_dashboard_msgs::IsInRemoteControl::Response& resp)
+{
+  resp.answer = this->client_.sendAndReceive("is in remote control\n");
+  std::regex expected("(true|false)");
+  std::smatch match;
+  resp.success = std::regex_match(resp.answer, match, expected);
+
+  if (resp.success)
+  {
+    resp.in_remote_control = (match[1] == "true");
   }
 
   return true;

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -121,7 +121,7 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
   is_program_saved_service_ = nh_.advertiseService("program_saved", &DashboardClientROS::handleSavedQuery, this);
 
   // Query whether the robot is in remote control
-  is_in_remote_control_service_ = 
+  is_in_remote_control_service_ =
       nh_.advertiseService("in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
 
   // Service to show a popup on the UR Teach pendant.

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -122,7 +122,7 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
 
   // Query whether the robot is in remote control
   is_in_remote_control_service_ =
-      nh_.advertiseService("in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
+      nh_.advertiseService("is_in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
 
   // Service to show a popup on the UR Teach pendant.
   popup_service_ = nh_.advertiseService<ur_dashboard_msgs::Popup::Request, ur_dashboard_msgs::Popup::Response>(

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -121,7 +121,8 @@ DashboardClientROS::DashboardClientROS(const ros::NodeHandle& nh, const std::str
   is_program_saved_service_ = nh_.advertiseService("program_saved", &DashboardClientROS::handleSavedQuery, this);
 
   // Query whether the robot is in remote control
-  is_in_remote_control_service_ = nh_.advertiseService("in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
+  is_in_remote_control_service_ = 
+      nh_.advertiseService("in_remote_control", &DashboardClientROS::handleRemoteControlQuery, this);
 
   // Service to show a popup on the UR Teach pendant.
   popup_service_ = nh_.advertiseService<ur_dashboard_msgs::Popup::Request, ur_dashboard_msgs::Popup::Response>(


### PR DESCRIPTION
This PR adds one of the missing calls, `is in remote control`, from the dashboard server.

This is accessible through `raw request` but I thought it would be better to have it here. I am currently using it to alert the remote operator. Sometimes people forget to set it back to remote mode after the manual operation.

After preparing the pr, I found out there is an issue-#76 raised to implement additional missing calls. @fmauch If you see it reasonable to add the remaining calls, I can prepare separate PRs for them.