### PR TITLE
Allow empty stopped_controllers argument.

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch
+++ b/ur_robot_driver/launch/ur_control.launch
@@ -77,8 +77,7 @@
 
   <!-- load other controller -->
   <node name="ros_control_stopped_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="--stopped $(arg stopped_controllers)" />
-
+    output="screen" args="--stopped $(arg stopped_controllers)" unless="$(eval arg('stopped_controllers') == '')"/>
 
   <node name="controller_stopper" pkg="controller_stopper" type="node" respawn="false" output="screen">
     <remap from="robot_running" to="ur_hardware_interface/robot_program_running"/>


### PR DESCRIPTION
This addresses issue #568, which just allows passing an empty `stopped_controllers` argument in the launch file. This allows one to completely avoid loading controllers which are not used, avoiding clutter in the controller manager.