### PR TITLE
Fix universal_robot clone destination in BUILDING

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ mkdir -p catkin_ws/src && cd catkin_ws
 $ git clone https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git src/Universal_Robots_ROS_Driver
 
 # clone the description. Currently, it is necessary to use the melodic-devel-staging branch.
-$ git clone -b melodic-devel-staging https://github.com/ros-industrial/universal_robot.git
+$ git clone -b melodic-devel-staging https://github.com/ros-industrial/universal_robot.git src/universal_robot
 
 # install dependencies
 $ sudo apt update -qq


### PR DESCRIPTION
`universal_robot` should be cloned to `catkin_ws/src` instead of `catkin_ws`.

The current command clones it to `catkin_ws`, which results in the following error:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
ur_robot_driver: Cannot locate rosdep definition for [ur_description]
```