### PR TITLE
Fix MoveIt! command in Example

### DIFF
--- a/ur_robot_driver/doc/usage_example.md
+++ b/ur_robot_driver/doc/usage_example.md
@@ -163,7 +163,7 @@ roslaunch ur_robot_driver ur5e_bringup.launch robot_ip:=192.168.56.101
 ```
 
 ```
-roslaunch ur5e_moveit_config ur5e_moveit_planning_execution.launch
+roslaunch ur5e_moveit_config moveit_planning_execution.launch
 ```
 
 ```


### PR DESCRIPTION
Should use [`moveit_planning_execution.launch`](https://github.com/ros-industrial/universal_robot/blob/melodic-devel-staging/ur5e_moveit_config/launch/moveit_planning_execution.launch) as described in [this commit](https://github.com/ros-industrial/universal_robot/commit/c4d07d781a9e1df68375752bb8dc052468e0bfca).

The current command uses `ur5e_moveit_planning_execution.launch`, which results in the following error:

```
RLException: [ur5e_moveit_planning_execution.launch] is neither a launch file in package [ur5e_moveit_config] nor is [ur5e_moveit_config] a launch file name
The traceback for the exception was written to the log file
```