### PR TITLE
[ROS-O] Drop old C++ compiler flags

### DIFF
--- a/controller_stopper/CMakeLists.txt
+++ b/controller_stopper/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(controller_stopper)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ur_calibration)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   ur_robot_driver

--- a/ur_dashboard_msgs/CMakeLists.txt
+++ b/ur_dashboard_msgs/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ur_dashboard_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -67,18 +67,6 @@ catkin_package(
     ur_client_library
 )
 
-# check c++11 / c++0x
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  add_compile_options(-std=c++11)
-elseif(COMPILER_SUPPORTS_CXX0X)
-  add_compile_options(-std=c++0x)
-else()
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
-endif()
-
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)


### PR DESCRIPTION
C++14 has been the default for clang and gcc since before Ubuntu 18.04 and enforcing the old standard breaks on systems with a current version of log4cxx (Ubuntu 22.04 +, Arch Linux, Lunar Linux, Debian Testing, ...)