### PR TITLE
Script command port

### DIFF
--- a/ur_robot_driver/doc/ROS_INTERFACE.md
+++ b/ur_robot_driver/doc/ROS_INTERFACE.md
@@ -49,6 +49,10 @@ Robot description launch file.
 
 IP address by which the robot can be reached.
 
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
+
 ##### script_sender_port (default: "50002")
 
 The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately.
@@ -150,6 +154,10 @@ Robot description launch file.
 
 IP address by which the robot can be reached.
 
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
+
 ##### script_sender_port (default: "50002")
 
 The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately.
@@ -210,6 +218,10 @@ Recipe file used for the RTDE-inputs. Only change this if you know what you're d
 ##### rtde_output_recipe_file (default: "$(find ur_robot_driver)/resources/rtde_output_recipe.txt")
 
 Recipe file used for the RTDE-outputs. Only change this if you know what you're doing.
+
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
 
 ##### script_sender_port (default: "50002")
 
@@ -308,6 +320,10 @@ Robot description launch file.
 
 IP address by which the robot can be reached.
 
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
+
 ##### script_sender_port (default: "50002")
 
 The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately.
@@ -401,6 +417,10 @@ Robot description launch file.
 
 IP address by which the robot can be reached.
 
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
+
 ##### script_sender_port (default: "50002")
 
 The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately.
@@ -457,6 +477,10 @@ Robot description launch file.
 ##### robot_ip (Required)
 
 IP address by which the robot can be reached.
+
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
 
 ##### script_sender_port (default: "50002")
 
@@ -551,6 +575,10 @@ Robot description launch file.
 
 IP address by which the robot can be reached.
 
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
+
 ##### script_sender_port (default: "50002")
 
 The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately.
@@ -607,6 +635,10 @@ Robot description launch file.
 ##### robot_ip (Required)
 
 IP address by which the robot can be reached.
+
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
 
 ##### script_sender_port (default: "50002")
 
@@ -833,6 +865,10 @@ The robot's IP address.
 ##### script_file (Required)
 
 Path to the urscript code that will be sent to the robot.
+
+##### script_command_port (default: "50004")
+
+Port that will be opened to forward script commands to the robot when in local control mode.
 
 ##### script_sender_port (Required)
 

--- a/ur_robot_driver/launch/ur10_bringup.launch
+++ b/ur_robot_driver/launch/ur10_bringup.launch
@@ -4,6 +4,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur10e_bringup.launch
+++ b/ur_robot_driver/launch/ur10e_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur16e_bringup.launch
+++ b/ur_robot_driver/launch/ur16e_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur3_bringup.launch
+++ b/ur_robot_driver/launch/ur3_bringup.launch
@@ -4,6 +4,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur3e_bringup.launch
+++ b/ur_robot_driver/launch/ur3e_bringup.launch
@@ -4,6 +4,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur5_bringup.launch
+++ b/ur_robot_driver/launch/ur5_bringup.launch
@@ -4,6 +4,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur5e_bringup.launch
+++ b/ur_robot_driver/launch/ur5e_bringup.launch
@@ -4,6 +4,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_robot_driver/launch/ur_common.launch
+++ b/ur_robot_driver/launch/ur_common.launch
@@ -6,6 +6,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description."/>
@@ -39,6 +40,7 @@
     <arg name="robot_ip" value="$(arg robot_ip)"/>
     <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="script_command_port" value="$(arg script_command_port)"/>
     <arg name="script_sender_port" value="$(arg script_sender_port)"/>
     <arg name="trajectory_port" value="$(arg trajectory_port)"/>
     <arg name="kinematics_config" value="$(arg kinematics_config)"/>

--- a/ur_robot_driver/launch/ur_control.launch
+++ b/ur_robot_driver/launch/ur_control.launch
@@ -11,6 +11,7 @@
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>
   <arg name="reverse_ip" default="" doc="IP of the driver, if set to empty it will detect it automatically."/>
   <arg name="reverse_port" default="50001" doc="Port that will be opened by the driver to allow direct communication between the driver and the robot controller."/>
+  <arg name="script_command_port" default="50004" doc="Port that will be opened to forward script commands to the robot when in local control mode"/>
   <arg name="script_sender_port" default="50002" doc="The driver will offer an interface to receive the program's URScript on this port. If the robot cannot connect to this port, `External Control` will stop immediately."/>
   <arg name="trajectory_port" default="50003" doc="Port that will be opened by the driver to allow trajectory forwarding."/>
   <arg name="kinematics_config" doc="Kinematics config file used for calibration correction. This will be used to verify the robot's calibration is matching the robot_description. Pass the same config file that is passed to the robot_description."/>
@@ -38,6 +39,7 @@
     <param name="robot_ip" type="str" value="$(arg robot_ip)"/>
     <param name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)"/>
+    <param name="script_command_port" type="int" value="$(arg script_command_port)"/>
     <param name="script_sender_port" type="int" value="$(arg script_sender_port)"/>
     <param name="trajectory_port" value="$(arg trajectory_port)"/>
     <rosparam command="load" file="$(arg kinematics_config)" />

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -1136,10 +1136,7 @@ bool HardwareInterface::zeroFTSensor(std_srvs::TriggerRequest& req, std_srvs::Tr
   }
   else
   {
-    res.success = this->ur_driver_->sendScript(R"(sec tareSensor():
-  zero_ftsensor()
-end
-)");
+    res.success = ur_driver_->zeroFTSensor();
   }
   return true;
 }

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -104,6 +104,9 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   // Port that will be opened to communicate between the driver and the robot controller.
   int reverse_port = robot_hw_nh.param("reverse_port", 50001);
 
+  // Port that will be opened to forward script commands to the robot when in local control mode
+  int script_command_port = robot_hw_nh.param("script_command_port", 50004);
+
   // The driver will offer an interface to receive the program's URScript on this port.
   int script_sender_port = robot_hw_nh.param("script_sender_port", 50002);
 
@@ -285,7 +288,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
         robot_ip_, script_filename, output_recipe_filename, input_recipe_filename,
         std::bind(&HardwareInterface::handleRobotProgramState, this, std::placeholders::_1), headless_mode,
         std::move(tool_comm_setup), (uint32_t)reverse_port, (uint32_t)script_sender_port, servoj_gain,
-        servoj_lookahead_time, non_blocking_read_, reverse_ip, trajectory_port));
+        servoj_lookahead_time, non_blocking_read_, reverse_ip, trajectory_port, script_command_port));
   }
   catch (urcl::ToolCommNotAvailable& e)
   {


### PR DESCRIPTION
I suddenly started having issues in a dual-UR setup in our lab. After a bit of digging, I found that a new reverse connection from the robot to the PC was ["recently" added to the client library](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/111). Since this new port is not configurable at the ROS driver level, it's currently impossible to run multi-UR ROS setups without all but one UR driver failing to initialize because of port collisions.

This PR adds this new parameter to the ROS driver node to allow configuring the port to use. It also uses the new `zeroFTSensor` method in `UrDriver`, which has the benefit of working both when Polyscope is in Local or Remote modes. I was not so sure of how the new `setToolVoltage` and `setPayload` in `UrDriver` could be used from the ROS driver, so I did nothing with those.