### PR TITLE
use released ur_description instead of building it from source

### DIFF
--- a/.melodic.rosinstall
+++ b/.melodic.rosinstall
@@ -1,4 +1,1 @@
-- git:
-    uri: https://github.com/ros-industrial/universal_robot.git
-    local-name: universal_robot
-    version: melodic-devel
+repositories:

--- a/.noetic.rosinstall
+++ b/.noetic.rosinstall
@@ -1,4 +1,1 @@
-- git:
-    uri: https://github.com/ros-industrial/universal_robot.git
-    local-name: universal_robot
-    version: melodic-devel
+repositories:


### PR DESCRIPTION
This PR aims at providing the new default stable branch. Since we released the universal_robots repository, we can start releasing the driver.

As a first step, I removed the rosinstall entries. At this stage the builds using the testing repo should succeed without any upstream workspace.