### PR TITLE
Update minimal required polyscope version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To create an issue on the [Issue Board](https://github.com/UniversalRobots/Unive
 If you need help using this driver, please see the ROS-category in the [UR+ Developer Forum](https://forum.universal-robots.com/c/ros). 
 
 ## Features
- * Works for all **CB3 (with software version >= 3.7) and e-Series (software >= 5.1)** robots and uses the RTDE interface for communication, whenever possible.
+ * Works for all **CB3 (with software version >= 3.12.0) and e-Series (software >= 5.5.1)** robots and uses the RTDE interface for communication, whenever possible.
  * **Factory calibration** of the robot inside ROS to reach Cartesian
    targets precisely.
  * **Realtime-enabled** communication structure to robustly cope with the 2ms cycle time of the
@@ -167,9 +167,6 @@ $ source devel_isolated/setup.bash
 ### Prepare the robot
 For using the *ur_robot_driver* with a real robot you need to install the
 **externalcontrol-x.x.x.urcap** which can be found [here](https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/releases).
-
-**Note**: For installing this URCap a minimal PolyScope version of 3.7 or 5.1 (in case of e-Series) is
-necessary.
 
 For installing the necessary URCap and creating a program, please see the individual tutorials on
 how to [setup a CB3 robot](ur_robot_driver/doc/install_urcap_cb3.md) or how to [setup an e-Series

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -296,7 +296,10 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   }
   catch (urcl::UrException& e)
   {
-    ROS_FATAL_STREAM(e.what());
+    ROS_FATAL_STREAM(e.what() << std::endl
+                              << "Please note that the minimum software version required is 3.12.0 for CB3 robots and "
+                                 "5.5.1 for e-Series robots. The error above could be related to a non-supported "
+                                 "polyscope version. Please update your robot's software accordingly.");
     return false;
   }
   URCL_LOG_INFO("Checking if calibration data matches connected robot.");


### PR DESCRIPTION
Since #566 we increased the minimum required Polyscope version, which we didn't document so far, leading to #599. This adds the required documentation and error output.