### PR TITLE
fix typo and use ros logging

### DIFF
--- a/ur_robot_driver/src/hardware_interface_node.cpp
+++ b/ur_robot_driver/src/hardware_interface_node.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
       ret = pthread_getschedparam(this_thread, &policy, &params);
       if (ret != 0)
       {
-        std::cout << "Couldn't retrieve real-time scheduling paramers" << std::endl;
+        ROS_ERROR("Couldn't retrieve real-time scheduling parameters");
       }
 
       // Check the correct policy was applied


### PR DESCRIPTION
as discovered in https://github.com/ros-industrial/kuka_experimental/pull/257