### PR TITLE
Add to doc, sometimes custom port must be blank

### DIFF
--- a/ur_robot_driver/doc/install_urcap_cb3.md
+++ b/ur_robot_driver/doc/install_urcap_cb3.md
@@ -33,6 +33,9 @@ Note that the robot and the external PC have to be in the same network, ideally 
 connection with each other to minimize network disturbances. The custom port should be left
 untouched for now.
 
+In some cases the custom port should be set to blank.
+If you recieve a warning/exeption when attempting to connect you may need to remove the custom port number.
+
  ![Insert the external control node](initial_setup_images/cb3_10_prog_structure_urcaps.png)
 
 To use the new URCaps, create a new program and insert the **External Control** program node into


### PR DESCRIPTION
In my experience getting the driver working I followed all the instructions including leave the custom port number untouched. However when I attempting to start communication between ROS on my PC and the UR5 robot the connection always failed.

I attempted to use (for the custom port) the port number that ROS was starting local host on, on my PC that I assume acts as the client interface to issue requests to the UR5 however this resulted in a more serious warning/exception that also immediately ended the communication from the UR5 side.

Then I was certain that the custom port number was the problem, removing the custom port completely. Setting it to blank. Immediately solved the problem and the driver worked perfectly. I am not able to run the move_python example that commands the robot to perform a manoeuvrer.

This solution may not work in all cases but I thought that it should be in the docs since I found nothing about this on any of the forums or the docs. It should help others get up and running more easily in the future. 