### PR TITLE
Implemented get version service

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -54,7 +54,7 @@
 #include <ur_msgs/SetIO.h>
 #include <ur_msgs/SetSpeedSliderFraction.h>
 #include <ur_msgs/SetPayload.h>
-#include <ur_msgs/GetVersion.h>
+#include <ur_msgs/GetRobotSoftwareVersion.h>
 
 #include <cartesian_interface/cartesian_command_interface.h>
 #include <cartesian_interface/cartesian_state_handle.h>
@@ -216,7 +216,7 @@ protected:
   void commandCallback(const std_msgs::StringConstPtr& msg);
   bool setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::SetPayloadResponse& res);
   bool activateSplineInterpolation(std_srvs::SetBoolRequest& req, std_srvs::SetBoolResponse& res);
-  bool getVersion(ur_msgs::GetVersionRequest& req, ur_msgs::GetVersionResponse& res);
+  bool getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req, ur_msgs::GetRobotSoftwareVersionResponse& res);
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
   std::unique_ptr<DashboardClientROS> dashboard_client_;
@@ -241,7 +241,7 @@ protected:
   ros::ServiceServer tare_sensor_srv_;
   ros::ServiceServer set_payload_srv_;
   ros::ServiceServer activate_spline_interpolation_srv_;
-  ros::ServiceServer get_version_srv;
+  ros::ServiceServer get_robot_software_version_srv;
 
   hardware_interface::JointStateInterface js_interface_;
   scaled_controllers::ScaledPositionJointInterface spj_interface_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -216,7 +216,8 @@ protected:
   void commandCallback(const std_msgs::StringConstPtr& msg);
   bool setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::SetPayloadResponse& res);
   bool activateSplineInterpolation(std_srvs::SetBoolRequest& req, std_srvs::SetBoolResponse& res);
-  bool getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req, ur_msgs::GetRobotSoftwareVersionResponse& res);
+  bool getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req,
+                               ur_msgs::GetRobotSoftwareVersionResponse& res);
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
   std::unique_ptr<DashboardClientROS> dashboard_client_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -54,6 +54,7 @@
 #include <ur_msgs/SetIO.h>
 #include <ur_msgs/SetSpeedSliderFraction.h>
 #include <ur_msgs/SetPayload.h>
+#include <ur_msgs/GetVersion.h>
 
 #include <cartesian_interface/cartesian_command_interface.h>
 #include <cartesian_interface/cartesian_state_handle.h>
@@ -215,6 +216,7 @@ protected:
   void commandCallback(const std_msgs::StringConstPtr& msg);
   bool setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::SetPayloadResponse& res);
   bool activateSplineInterpolation(std_srvs::SetBoolRequest& req, std_srvs::SetBoolResponse& res);
+  bool getVersion(ur_msgs::GetVersionRequest& req, ur_msgs::GetVersionResponse& res);
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
   std::unique_ptr<DashboardClientROS> dashboard_client_;
@@ -239,6 +241,7 @@ protected:
   ros::ServiceServer tare_sensor_srv_;
   ros::ServiceServer set_payload_srv_;
   ros::ServiceServer activate_spline_interpolation_srv_;
+  ros::ServiceServer get_version_srv;
 
   hardware_interface::JointStateInterface js_interface_;
   scaled_controllers::ScaledPositionJointInterface spj_interface_;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -461,7 +461,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
       "activate_spline_interpolation", &HardwareInterface::activateSplineInterpolation, this);
 
   // Calling this service will return the software version of the robot.
-  get_version_srv = robot_hw_nh.advertiseService("get_version", &HardwareInterface::getVersion, this);
+  get_robot_software_version_srv = robot_hw_nh.advertiseService("get_robot_software_version", &HardwareInterface::getRobotSoftwareVersion, this);
 
   ur_driver_->startRTDECommunication();
   ROS_INFO_STREAM_NAMED("hardware_interface", "Loaded ur_robot_driver hardware_interface");
@@ -1178,7 +1178,7 @@ bool HardwareInterface::setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::Set
   return true;
 }
 
-bool HardwareInterface::getVersion(ur_msgs::GetVersionRequest& req, ur_msgs::GetVersionResponse& res)
+bool HardwareInterface::getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req, ur_msgs::GetRobotSoftwareVersionResponse& res)
 {
   urcl::VersionInformation version_info = this->ur_driver_->getVersion();
   res.major = version_info.major;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -460,6 +460,9 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   activate_spline_interpolation_srv_ = robot_hw_nh.advertiseService(
       "activate_spline_interpolation", &HardwareInterface::activateSplineInterpolation, this);
 
+  // Calling this service will return the software version of the robot.
+  get_version_srv = robot_hw_nh.advertiseService("get_version", &HardwareInterface::getVersion, this);
+
   ur_driver_->startRTDECommunication();
   ROS_INFO_STREAM_NAMED("hardware_interface", "Loaded ur_robot_driver hardware_interface");
 
@@ -1172,6 +1175,16 @@ bool HardwareInterface::setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::Set
   cog[1] = req.center_of_gravity.y;
   cog[2] = req.center_of_gravity.z;
   res.success = this->ur_driver_->setPayload(req.mass, cog);
+  return true;
+}
+
+bool HardwareInterface::getVersion(ur_msgs::GetVersionRequest& req, ur_msgs::GetVersionResponse& res)
+{
+  urcl::VersionInformation version_info = this->ur_driver_->getVersion();
+  res.major = version_info.major;
+  res.minor = version_info.minor;
+  res.bugfix = version_info.bugfix;
+  res.build = version_info.build;
   return true;
 }
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -461,7 +461,8 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
       "activate_spline_interpolation", &HardwareInterface::activateSplineInterpolation, this);
 
   // Calling this service will return the software version of the robot.
-  get_robot_software_version_srv = robot_hw_nh.advertiseService("get_robot_software_version", &HardwareInterface::getRobotSoftwareVersion, this);
+  get_robot_software_version_srv =
+      robot_hw_nh.advertiseService("get_robot_software_version", &HardwareInterface::getRobotSoftwareVersion, this);
 
   ur_driver_->startRTDECommunication();
   ROS_INFO_STREAM_NAMED("hardware_interface", "Loaded ur_robot_driver hardware_interface");
@@ -1178,7 +1179,8 @@ bool HardwareInterface::setPayload(ur_msgs::SetPayloadRequest& req, ur_msgs::Set
   return true;
 }
 
-bool HardwareInterface::getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req, ur_msgs::GetRobotSoftwareVersionResponse& res)
+bool HardwareInterface::getRobotSoftwareVersion(ur_msgs::GetRobotSoftwareVersionRequest& req,
+                                                ur_msgs::GetRobotSoftwareVersionResponse& res)
 {
   urcl::VersionInformation version_info = this->ur_driver_->getVersion();
   res.major = version_info.major;

--- a/ur_robot_driver/test/integration_test.py
+++ b/ur_robot_driver/test/integration_test.py
@@ -128,22 +128,6 @@ class IntegrationTest(unittest.TestCase):
                 "Could not reach 'get version' service. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
-        self.start_tool_contact = rospy.ServiceProxy('ur_hardware_interface/start_tool_contact', Trigger)
-        try:
-            self.start_tool_contact.wait_for_service(timeout)
-        except rospy.exceptions.ROSException as err:
-            self.fail(
-                "Could not reach 'start tool contact' service. Make sure that the driver is actually running."
-                " Msg: {}".format(err))
-
-        self.end_tool_contact = rospy.ServiceProxy('ur_hardware_interface/end_tool_contact', Trigger)
-        try:
-            self.end_tool_contact.wait_for_service(timeout)
-        except rospy.exceptions.ROSException as err:
-            self.fail(
-                "Could not reach 'end tool contact' service. Make sure that the driver is actually running."
-                " Msg: {}".format(err))
-
         self.script_publisher = rospy.Publisher("/ur_hardware_interface/script_command", std_msgs.msg.String, queue_size=1)
         self.tf_listener = tf.TransformListener()
         self.twist_pub = rospy.Publisher("/twist_controller/command", geometry_msgs.msg.Twist, queue_size=1)
@@ -285,21 +269,6 @@ class IntegrationTest(unittest.TestCase):
             pin_state = io_state.digital_out_states[pin].state
             messages += 1
         self.assertEqual(pin_state, 1)
-
-    def test_tool_contact(self):
-        version_info = self.get_robot_software_version.call()
-        if version_info.major >= 5:
-            start_response = self.start_tool_contact.call()
-            self.assertEqual(start_response.success,True)
-
-            end_response = self.end_tool_contact.call()
-            self.assertEqual(end_response.success, True)
-        else:
-            start_response = self.start_tool_contact.call()
-            self.assertEqual(start_response.success,False)
-
-            end_response = self.end_tool_contact.call()
-            self.assertEqual(end_response.success, False)
 
     def test_cartesian_passthrough(self):
         #### Power cycle the robot in order to make sure it is running correctly####

--- a/ur_robot_driver/test/integration_test.py
+++ b/ur_robot_driver/test/integration_test.py
@@ -15,7 +15,7 @@ from ur_dashboard_msgs.msg import SetModeAction, SetModeGoal, RobotMode
 from std_srvs.srv import Trigger, TriggerRequest
 import tf
 from trajectory_msgs.msg import JointTrajectoryPoint
-from ur_msgs.srv import SetIO, SetIORequest, GetVersion
+from ur_msgs.srv import SetIO, SetIORequest, GetRobotSoftwareVersion
 from ur_msgs.msg import IOStates
 
 from cartesian_control_msgs.msg import (
@@ -120,9 +120,9 @@ class IntegrationTest(unittest.TestCase):
                 "actually running in headless mode."
                 " Msg: {}".format(err))
 
-        self.get_version = rospy.ServiceProxy("ur_hardware_interface/get_version", GetVersion)
+        self.get_robot_software_version = rospy.ServiceProxy("ur_hardware_interface/get_robot_software_version", GetRobotSoftwareVersion)
         try:
-            self.get_version.wait_for_service(timeout)
+            self.get_robot_software_version.wait_for_service(timeout)
         except rospy.exceptions.ROSException as err:
             self.fail(
                 "Could not reach 'get version' service. Make sure that the driver is actually running."
@@ -287,7 +287,7 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(pin_state, 1)
 
     def test_tool_contact(self):
-        version_info = self.get_version.call()
+        version_info = self.get_robot_software_version.call()
         if version_info.major >= 5:
             start_response = self.start_tool_contact.call()
             self.assertEqual(start_response.success,True)

--- a/ur_robot_driver/test/integration_test.py
+++ b/ur_robot_driver/test/integration_test.py
@@ -15,7 +15,7 @@ from ur_dashboard_msgs.msg import SetModeAction, SetModeGoal, RobotMode
 from std_srvs.srv import Trigger, TriggerRequest
 import tf
 from trajectory_msgs.msg import JointTrajectoryPoint
-from ur_msgs.srv import SetIO, SetIORequest
+from ur_msgs.srv import SetIO, SetIORequest, GetVersion
 from ur_msgs.msg import IOStates
 
 from cartesian_control_msgs.msg import (
@@ -118,6 +118,30 @@ class IntegrationTest(unittest.TestCase):
             self.fail(
                 "Could not reach resend_robot_program service. Make sure that the driver is "
                 "actually running in headless mode."
+                " Msg: {}".format(err))
+
+        self.get_version = rospy.ServiceProxy("ur_hardware_interface/get_version", GetVersion)
+        try:
+            self.get_version.wait_for_service(timeout)
+        except rospy.exceptions.ROSException as err:
+            self.fail(
+                "Could not reach 'get version' service. Make sure that the driver is actually running."
+                " Msg: {}".format(err))
+
+        self.start_tool_contact = rospy.ServiceProxy('ur_hardware_interface/start_tool_contact', Trigger)
+        try:
+            self.start_tool_contact.wait_for_service(timeout)
+        except rospy.exceptions.ROSException as err:
+            self.fail(
+                "Could not reach 'start tool contact' service. Make sure that the driver is actually running."
+                " Msg: {}".format(err))
+
+        self.end_tool_contact = rospy.ServiceProxy('ur_hardware_interface/end_tool_contact', Trigger)
+        try:
+            self.end_tool_contact.wait_for_service(timeout)
+        except rospy.exceptions.ROSException as err:
+            self.fail(
+                "Could not reach 'end tool contact' service. Make sure that the driver is actually running."
                 " Msg: {}".format(err))
 
         self.script_publisher = rospy.Publisher("/ur_hardware_interface/script_command", std_msgs.msg.String, queue_size=1)
@@ -261,6 +285,21 @@ class IntegrationTest(unittest.TestCase):
             pin_state = io_state.digital_out_states[pin].state
             messages += 1
         self.assertEqual(pin_state, 1)
+
+    def test_tool_contact(self):
+        version_info = self.get_version.call()
+        if version_info.major >= 5:
+            start_response = self.start_tool_contact.call()
+            self.assertEqual(start_response.success,True)
+
+            end_response = self.end_tool_contact.call()
+            self.assertEqual(end_response.success, True)
+        else:
+            start_response = self.start_tool_contact.call()
+            self.assertEqual(start_response.success,False)
+
+            end_response = self.end_tool_contact.call()
+            self.assertEqual(end_response.success, False)
 
     def test_cartesian_passthrough(self):
         #### Power cycle the robot in order to make sure it is running correctly####


### PR DESCRIPTION
And integrated it with the tool contact test. This service will obtain the software version of the robot, which can be useful for certain functionalities that only work on e-series robots, for example. This PR depends on [PR](https://github.com/ros-industrial/ur_msgs/pull/24) for functionality and [PR](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/686) for the integration test to work. 