### PR TITLE
Update the minimum required polyscope version in the output

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -306,8 +306,8 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   catch (urcl::UrException& e)
   {
     ROS_FATAL_STREAM(e.what() << std::endl
-                              << "Please note that the minimum software version required is 3.12.0 for CB3 robots and "
-                                 "5.5.1 for e-Series robots. The error above could be related to a non-supported "
+                              << "Please note that the minimum software version required is 3.14.3 for CB3 robots and "
+                                 "5.9.4 for e-Series robots. The error above could be related to a non-supported "
                                  "polyscope version. Please update your robot's software accordingly.");
     return false;
   }


### PR DESCRIPTION
When we raised the version requirements to 3.14/5.9 we didn't update the output in the ROS driver.